### PR TITLE
Pass MouseEvent to onDoubleClickCell

### DIFF
--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -27,7 +27,7 @@ interface TableProps {
   padding?: number // number of padding rows to render outside of the viewport
   focus?: boolean // focus table on mount? (default true)
   tableControl?: TableControl // control the table from outside
-  onDoubleClickCell?: (col: number, row: number) => void
+  onDoubleClickCell?: (event: React.MouseEvent, col: number, row: number) => void
   onMouseDownCell?: (event: React.MouseEvent, col: number, row: number) => void
   onError?: (error: Error) => void
 }
@@ -249,7 +249,7 @@ export default function HighTable({
     return <td
       className={str === undefined ? 'pending' : undefined}
       key={col}
-      onDoubleClick={() => onDoubleClickCell?.(col, rowIndex ?? row)}
+      onDoubleClick={e => onDoubleClickCell?.(e, col, rowIndex ?? row)}
       onMouseDown={e => onMouseDownCell?.(e, col, rowIndex ?? row)}
       style={memoizedStyles[col]}
       title={title}>

--- a/test/HighTable.test.tsx
+++ b/test/HighTable.test.tsx
@@ -63,7 +63,17 @@ describe('HighTable', () => {
 
     fireEvent.doubleClick(cell)
 
-    expect(mockDoubleClick).toHaveBeenCalledWith(1, 0)
+    expect(mockDoubleClick).toHaveBeenCalledWith(expect.anything(), 1, 0)
+  })
+
+  it('correctly handles middle click on cell', async () => {
+    const mockMiddleClick = vi.fn()
+    const { findByText } = render(<HighTable data={mockData} onMouseDownCell={mockMiddleClick} />)
+    const cell = await findByText('Name 0')
+
+    fireEvent.mouseDown(cell, { button: 1 })
+
+    expect(mockMiddleClick).toHaveBeenCalledWith(expect.anything(), 1, 0)
   })
 
   it('displays error when data fetch fails', async () => {


### PR DESCRIPTION
This change makes `onDoubleClickCell` consistent with `onMouseDownCell` by passing the React.MouseEvent as the first argument. This is helpful because sometimes you want access to the mouse event, either to get more info, or potentially prevent default, etc.

BREAKING CHANGE: Any packages that depend on hightable and use `onDoubleClickCell` needs to change their type signature! When published this needs to be hightable v0.8.0.
