### PR TITLE
Select rows, one by one

### DIFF
--- a/src/HighTable.css
+++ b/src/HighTable.css
@@ -116,13 +116,10 @@
   display: inline;
 }
 .table.selectable tr.selected {
-  background-color: #e4e4e8;
-}
-.table.selectable tr.selected td {
-  border-right-color: #bbb;
+  background-color: #fbf7bf;
 }
 .table.selectable tr.selected td:first-child {
-  background-color: #d0d0d8;
+  background-color: #f1edbb;
 }
 
 /* cells */

--- a/src/HighTable.css
+++ b/src/HighTable.css
@@ -109,19 +109,19 @@
 .table td:first-child input {
   display: none;
 }
-.table td:first-child:hover span, .table tr.selected td:first-child span {
+.table.selectable td:first-child:hover span, .table.selectable tr.selected td:first-child span {
   display: none;
 }
-.table td:first-child:hover input, .table tr.selected td:first-child input {
+.table.selectable td:first-child:hover input, .table.selectable tr.selected td:first-child input {
   display: inline;
 }
-.table tr.selected {
+.table.selectable tr.selected {
   background-color: #e4e4e8;
 }
-.table tr.selected td {
+.table.selectable tr.selected td {
   border-right-color: #bbb;
 }
-.table tr.selected td:first-child {
+.table.selectable tr.selected td:first-child {
   background-color: #d0d0d8;
 }
 

--- a/src/HighTable.css
+++ b/src/HighTable.css
@@ -103,6 +103,27 @@
   max-width: none;
   width: 32px;
 }
+.table td:first-child span {
+  display: inline;
+}
+.table td:first-child input {
+  display: none;
+}
+.table td:first-child:hover span, .table tr.selected td:first-child span {
+  display: none;
+}
+.table td:first-child:hover input, .table tr.selected td:first-child input {
+  display: inline;
+}
+.table tr.selected {
+  background-color: #e4e4e8;
+}
+.table tr.selected td {
+  border-right-color: #bbb;
+}
+.table tr.selected td:first-child {
+  background-color: #d0d0d8;
+}
 
 /* cells */
 .table th,

--- a/src/HighTable.css
+++ b/src/HighTable.css
@@ -102,6 +102,7 @@
   min-width: 32px;
   max-width: none;
   width: 32px;
+  cursor: pointer;
 }
 .table td:first-child span {
   display: inline;
@@ -114,6 +115,7 @@
 }
 .table.selectable td:first-child:hover input, .table.selectable tr.selected td:first-child input {
   display: inline;
+  cursor: pointer;
 }
 .table.selectable tr.selected {
   background-color: #fbf7bf;

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -28,6 +28,7 @@ interface TableProps {
   padding?: number // number of padding rows to render outside of the viewport
   focus?: boolean // focus table on mount? (default true)
   tableControl?: TableControl // control the table from outside
+  selectable?: boolean // enable row selection (default false)
   onDoubleClickCell?: (event: React.MouseEvent, col: number, row: number) => void
   onMouseDownCell?: (event: React.MouseEvent, col: number, row: number) => void
   onError?: (error: Error) => void
@@ -103,6 +104,7 @@ export default function HighTable({
   padding = 20,
   focus = true,
   tableControl,
+  selectable = false,
   onDoubleClickCell,
   onMouseDownCell,
   onError = console.error,
@@ -294,7 +296,7 @@ export default function HighTable({
         <table
           aria-colcount={data.header.length}
           aria-rowcount={data.numRows}
-          className={data.sortable ? 'table sortable' : 'table'}
+          className={`table${data.sortable ? ' sortable' : ''}${selectable ? ' selectable' : ''}`}
           ref={tableRef}
           role='grid'
           style={{ top: `${offsetTopRef.current}px` }}
@@ -317,8 +319,8 @@ export default function HighTable({
               </tr>
             )}
             {rows.map((row, rowIndex) =>
-              <tr key={startIndex + rowIndex} title={rowError(row, rowIndex)} className={isSelected({ selection, index: rowNumber(rowIndex) }) ? 'selected' : undefined}>
-                <td style={cornerStyle} onClick={() => dispatch({ type: 'SET_SELECTION', selection: toggleIndex({ selection, index: rowNumber(rowIndex) }) })}>
+              <tr key={startIndex + rowIndex} title={rowError(row, rowIndex)} className={isSelected({ selection, index: rowNumber(rowIndex) }) ? 'selected' : ''}>
+                <td style={cornerStyle} onClick={() => selectable && dispatch({ type: 'SET_SELECTION', selection: toggleIndex({ selection, index: rowNumber(rowIndex) }) })}>
                   <span>{rowNumber(rowIndex).toLocaleString()}</span>
                   <input type='checkbox' checked={isSelected({ selection, index: rowNumber(rowIndex) })} />
                 </td>

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,0 +1,102 @@
+/**
+ * A selection is an array of ordered and non-overlapping ranges.
+ * The ranges are separated, ie. the end of one range is strictly less than the start of the next range.
+ */
+export type Selection = Array<Range>
+
+interface Range {
+    start: number // inclusive lower limit, positive integer
+    end: number // exclusive upper limit, positive integer or Infinity, strictly greater than start (no zero-length ranges).
+}
+
+export function isValidIndex(index: number): boolean {
+  return Number.isInteger(index) && index >= 0
+}
+
+export function isValidRange(range: Range): boolean {
+  return isValidIndex(range.start)
+    && (isValidIndex(range.end) || range.end === Infinity)
+    && range.end > range.start
+}
+
+export function isValidSelection(selection: Selection): boolean {
+  if (selection.length === 0) {
+    return true
+  }
+  if (selection.some(range => !isValidRange(range))) {
+    return false
+  }
+  for (let i = 0; i < selection.length - 1; i++) {
+    if (selection[i].end >= selection[i + 1].start) {
+      return false
+    }
+  }
+  return true
+}
+
+export function toggleIndex({ selection, index }: {selection: Selection, index: number}): Selection {
+  if (!isValidIndex(index)) {
+    throw new Error('Invalid index')
+  }
+  if (!isValidSelection(selection)) {
+    throw new Error('Invalid selection')
+  }
+
+  if (selection.length === 0) {
+    return [{ start: index, end: index + 1 }]
+  }
+
+  const newSelection: Selection = []
+  let rangeIndex = 0
+
+  // copy the ranges before the index
+  while (rangeIndex < selection.length && selection[rangeIndex].end < index) {
+    newSelection.push({ ...selection[rangeIndex] })
+    rangeIndex++
+  }
+
+  if (rangeIndex < selection.length && selection[rangeIndex].start <= index + 1) {
+    // the index affects one or two ranges
+    const { start, end } = selection[rangeIndex]
+    if (start === index + 1) {
+      // prepend the range with the index
+      newSelection.push({ start: index, end })
+      rangeIndex++
+    } else if (end === index) {
+      // two cases:
+      if (rangeIndex + 1 < selection.length && selection[rangeIndex + 1].start === index + 1) {
+        // merge with following range
+        newSelection.push({ start, end: selection[rangeIndex + 1].end })
+        rangeIndex += 2
+      } else {
+        // extend the range to the index
+        newSelection.push({ start, end: index + 1 })
+        rangeIndex++
+      }
+    } else {
+      // the index is inside the range, and must be removed
+      if (start === index) {
+        newSelection.push({ start: index + 1, end })
+        rangeIndex++
+      } else if (end === index + 1) {
+        newSelection.push({ start, end: index })
+        rangeIndex++
+      } else {
+        newSelection.push({ start, end: index })
+        newSelection.push({ start: index + 1, end })
+        rangeIndex++
+      }
+    }
+  } else {
+    // insert a new range for the index
+    newSelection.push({ start: index, end: index + 1 })
+  }
+
+  // copy the remaining ranges
+  while (rangeIndex < selection.length) {
+    newSelection.push({ ...selection[rangeIndex] })
+    rangeIndex++
+  }
+
+  return newSelection
+}

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -61,32 +61,31 @@ export function toggleIndex({ selection, index }: {selection: Selection, index: 
     if (start === index + 1) {
       // prepend the range with the index
       newSelection.push({ start: index, end })
-      rangeIndex++
     } else if (end === index) {
       // two cases:
       if (rangeIndex + 1 < selection.length && selection[rangeIndex + 1].start === index + 1) {
         // merge with following range
         newSelection.push({ start, end: selection[rangeIndex + 1].end })
-        rangeIndex += 2
+        rangeIndex ++ // remove the following range
       } else {
         // extend the range to the index
         newSelection.push({ start, end: index + 1 })
-        rangeIndex++
       }
     } else {
       // the index is inside the range, and must be removed
       if (start === index) {
-        newSelection.push({ start: index + 1, end })
-        rangeIndex++
+        if (end > index + 1) {
+          newSelection.push({ start: index + 1, end })
+        }
+        // else: the range is removed
       } else if (end === index + 1) {
         newSelection.push({ start, end: index })
-        rangeIndex++
       } else {
         newSelection.push({ start, end: index })
         newSelection.push({ start: index + 1, end })
-        rangeIndex++
       }
     }
+    rangeIndex++
   } else {
     // insert a new range for the index
     newSelection.push({ start: index, end: index + 1 })
@@ -99,4 +98,8 @@ export function toggleIndex({ selection, index }: {selection: Selection, index: 
   }
 
   return newSelection
+}
+
+export function isSelected({ selection, index }: {selection: Selection, index: number}): boolean {
+  return selection.some(range => range.start <= index && index < range.end)
 }

--- a/test/selection.test.ts
+++ b/test/selection.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+import { isValidIndex, isValidRange, isValidSelection, toggleIndex } from '../src/selection.js'
+
+describe('an index', () => {
+  test('is a positive integer', () => {
+    expect(isValidIndex(0)).toBe(true)
+    expect(isValidIndex(1)).toBe(true)
+    expect(isValidIndex(1.5)).toBe(false)
+    expect(isValidIndex(-1)).toBe(false)
+    expect(isValidIndex(NaN)).toBe(false)
+    expect(isValidIndex(Infinity)).toBe(false)
+  })
+})
+
+describe('a range', () => {
+  test('cannot be empty', () => {
+    expect(isValidRange({ start: 7, end: 7 })).toBe(false)
+  })
+
+  test('expects end to be greater than start', () => {
+    expect(isValidRange({ start: 7, end: 8 })).toBe(true)
+    expect(isValidRange({ start: 8, end: 7 })).toBe(false)
+  })
+
+  test('expects start and end to be positive integers', () => {
+    expect(isValidRange({ start: 0, end: 1 })).toBe(true)
+    expect(isValidRange({ start: 0, end: 1.5 })).toBe(false)
+    expect(isValidRange({ start: -1, end: 1 })).toBe(false)
+    expect(isValidRange({ start: 0, end: NaN })).toBe(false)
+  })
+
+  test('accepts Infinity as the end boundary', () => {
+    expect(isValidRange({ start: 0, end: Infinity })).toBe(true)
+    expect(isValidRange({ start: Infinity, end: Infinity })).toBe(false)
+  })
+})
+
+describe('a selection', () => {
+  test('can be empty', () => {
+    expect(isValidSelection([])).toBe(true)
+  })
+
+  test('has valid ranges', () => {
+    expect(isValidSelection([{ start: 0, end: 1 }])).toBe(true)
+    expect(isValidSelection([{ start: 0, end: Infinity }])).toBe(true)
+    expect(isValidSelection([{ start: 1, end: 0 }])).toBe(false)
+    expect(isValidSelection([{ start: -1, end: 1 }])).toBe(false)
+    expect(isValidSelection([{ start: NaN, end: 1 }])).toBe(false)
+  })
+
+  test('has ordered ranges', () => {
+    expect(isValidSelection([{ start: 0, end: 1 }, { start: 2, end: Infinity }])).toBe(true)
+    expect(isValidSelection([{ start: 2, end: 3 }, { start: 0, end: 1 }])).toBe(false)
+  })
+
+  test('has non-overlapping, separated ranges', () => {
+    expect(isValidSelection([{ start: 0, end: 1 }, { start: 2, end: 3 }])).toBe(true)
+    expect(isValidSelection([{ start: 0, end: 1 }, { start: 0, end: 1 }])).toBe(false)
+    expect(isValidSelection([{ start: 0, end: 2 }, { start: 1, end: 3 }])).toBe(false)
+    expect(isValidSelection([{ start: 0, end: 2 }, { start: 2, end: 3 }])).toBe(false)
+  })
+
+  test('can contain any number of ranges', () => {
+    expect(isValidSelection([{ start: 0, end: 1 }, { start: 2, end: 3 }, { start: 4, end: 5 }])).toBe(true)
+  })
+})
+
+describe('toggling an index', () => {
+  test('should throw an error if the index is invalid', () => {
+    expect(() => toggleIndex({ selection: [], index: -1 })).toThrow('Invalid index')
+  })
+
+  test('should throw an error if the selection is invalid', () => {
+    expect(() => toggleIndex({ selection: [{ start: 1, end: 0 }], index: 0 })).toThrow('Invalid selection')
+  })
+
+  test('should add a new range if outside and separated from existing ranges', () => {
+    expect(toggleIndex({ selection: [], index: 0 })).toEqual([{ start: 0, end: 1 }])
+    expect(toggleIndex({ selection: [{ start: 0, end: 1 }, { start: 4, end: 5 }], index: 2 })).toEqual([{ start: 0, end: 1 }, { start: 2, end: 3 }, { start: 4, end: 5 }])
+  })
+
+  test('should merge with the previous and/or following ranges if adjacent', () => {
+    expect(toggleIndex({ selection: [{ start: 0, end: 1 }], index: 1 })).toEqual([{ start: 0, end: 2 }])
+    expect(toggleIndex({ selection: [{ start: 1, end: 2 }], index: 0 })).toEqual([{ start: 0, end: 2 }])
+    expect(toggleIndex({ selection: [{ start: 0, end: 1 }, { start: 2, end: 3 }], index: 1 })).toEqual([{ start: 0, end: 3 }])
+  })
+
+  test('shoud split a range if the index is inside', () => {
+    expect(toggleIndex({ selection: [{ start: 0, end: 2 }], index: 1 })).toEqual([{ start: 0, end: 1 }])
+    expect(toggleIndex({ selection: [{ start: 0, end: 2 }], index: 0 })).toEqual([{ start: 1, end: 2 }])
+    expect(toggleIndex({ selection: [{ start: 0, end: 3 }], index: 1 })).toEqual([{ start: 0, end: 1 }, { start: 2, end: 3 }])
+  })
+})

--- a/test/selection.test.ts
+++ b/test/selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { isValidIndex, isValidRange, isValidSelection, toggleIndex } from '../src/selection.js'
+import { isSelected, isValidIndex, isValidRange, isValidSelection, toggleIndex } from '../src/selection.js'
 
 describe('an index', () => {
   test('is a positive integer', () => {
@@ -85,9 +85,27 @@ describe('toggling an index', () => {
     expect(toggleIndex({ selection: [{ start: 0, end: 1 }, { start: 2, end: 3 }], index: 1 })).toEqual([{ start: 0, end: 3 }])
   })
 
-  test('shoud split a range if the index is inside', () => {
+  test('should split a range if the index is inside', () => {
     expect(toggleIndex({ selection: [{ start: 0, end: 2 }], index: 1 })).toEqual([{ start: 0, end: 1 }])
     expect(toggleIndex({ selection: [{ start: 0, end: 2 }], index: 0 })).toEqual([{ start: 1, end: 2 }])
     expect(toggleIndex({ selection: [{ start: 0, end: 3 }], index: 1 })).toEqual([{ start: 0, end: 1 }, { start: 2, end: 3 }])
+  })
+
+  test('should remove a range if it\'s only the index', () => {
+    expect(toggleIndex({ selection: [{ start: 0, end: 1 }], index: 0 })).toEqual([])
+  })
+
+  test('twice should be idempotent', () => {
+    const a = toggleIndex({ selection: [], index: 0 })
+    const b = toggleIndex({ selection: a, index: 0 })
+    expect(b).toEqual([])
+  })
+})
+
+describe('isSelected', () => {
+  test('should return true if the index is selected', () => {
+    expect(isSelected({ selection: [{ start: 0, end: 1 }], index: 0 })).toBe(true)
+    expect(isSelected({ selection: [{ start: 0, end: Infinity }], index: 1 })).toBe(true)
+    expect(isSelected({ selection: [{ start: 0, end: 1 }], index: 1 })).toBe(false)
   })
 })


### PR DESCRIPTION

[Screencast From 2025-01-06 23-59-18.webm](https://github.com/user-attachments/assets/ecc74bb6-d020-4f19-8f92-1ad4f5687048)


The selected rows are in the dispatched state, as an array of ranges: `selection: {start: number, end: number}[]`.

We show a checkbox when hovering the row number, or when a row is selected. Same behavior as Airtable.

Next steps:
- add a checkbox in the top left cell (instead of the hyperparam logo) to select/unselect all the rows
- select/unselect multiple rows with shift+click
- select/unselect multiple rows with drag/drop on the checkboxes