### PR TITLE
Select rows range with shift

### DIFF
--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -335,7 +335,7 @@ export default function HighTable({
             )}
             {rows.map((row, rowIndex) =>
               <tr key={startIndex + rowIndex} title={rowError(row, rowIndex)} className={isSelected({ selection, index: rowNumber(rowIndex) }) ? 'selected' : ''}>
-                <td style={cornerStyle} onClick={(event) => onRowNumberClick({ useAnchor: event.shiftKey, index: rowNumber(rowIndex) })}>
+                <td style={cornerStyle} onClick={event => onRowNumberClick({ useAnchor: event.shiftKey, index: rowNumber(rowIndex) })}>
                   <span>{rowNumber(rowIndex).toLocaleString()}</span>
                   <input type='checkbox' checked={isSelected({ selection, index: rowNumber(rowIndex) })} />
                 </td>

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -139,30 +139,30 @@ export function unselectRange({ selection, range }: {selection: Selection, range
 }
 
 /**
- * Extend selection state from bound1 to bound2 (selecting or unselecting the range).
+ * Extend selection state from anchor to index (selecting or unselecting the range).
  * Both bounds are inclusive.
- * It will handle the shift+click behavior. bound1 is the first index clicked, bound2 is the last index clicked.
+ * It will handle the shift+click behavior. anchor is the first index clicked, index is the last index clicked.
  */
-export function extendToBound({ selection, bound1, bound2 }: {selection: Selection, bound1?: number, bound2: number}): Selection {
+export function extendFromAnchor({ selection, anchor, index }: {selection: Selection, anchor?: number, index: number}): Selection {
   if (!isValidSelection(selection)) {
     throw new Error('Invalid selection')
   }
-  if (bound1 === undefined) {
-    // no initial bound, no operation
+  if (anchor === undefined) {
+    // no anchor to start the range, no operation
     return selection
   }
-  if (!isValidIndex(bound1) || !isValidIndex(bound2)) {
+  if (!isValidIndex(anchor) || !isValidIndex(index)) {
     throw new Error('Invalid index')
   }
-  if (bound1 === bound2) {
+  if (anchor === index) {
     // no operation
     return selection
   }
-  const range = bound1 < bound2 ? { start: bound1, end: bound2 + 1 } : { start: bound2, end: bound1 + 1 }
+  const range = anchor < index ? { start: anchor, end: index + 1 } : { start: index, end: anchor + 1 }
   if (!isValidRange(range)) {
     throw new Error('Invalid range')
   }
-  if (isSelected({ selection, index: bound1 })) {
+  if (isSelected({ selection, index: anchor })) {
     // select the rest of the range
     return selectRange({ selection, range })
   } else {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -34,7 +34,7 @@ export function isValidSelection(selection: Selection): boolean {
   return true
 }
 
-export function isSelected({ selection, index }: {selection: Selection, index: number}): boolean {
+export function isSelected({ selection, index }: { selection: Selection, index: number }): boolean {
   if (!isValidIndex(index)) {
     throw new Error('Invalid index')
   }
@@ -67,7 +67,7 @@ export function toggleAll({ selection, length }: { selection: Selection, length:
   return [{ start: 0, end: length }]
 }
 
-export function selectRange({ selection, range }: {selection: Selection, range: Range}): Selection {
+export function selectRange({ selection, range }: { selection: Selection, range: Range }): Selection {
   if (!isValidSelection(selection)) {
     throw new Error('Invalid selection')
   }
@@ -101,7 +101,7 @@ export function selectRange({ selection, range }: {selection: Selection, range: 
   return newSelection
 }
 
-export function unselectRange({ selection, range }: {selection: Selection, range: Range}): Selection {
+export function unselectRange({ selection, range }: { selection: Selection, range: Range }): Selection {
   if (!isValidSelection(selection)) {
     throw new Error('Invalid selection')
   }
@@ -143,7 +143,7 @@ export function unselectRange({ selection, range }: {selection: Selection, range
  * Both bounds are inclusive.
  * It will handle the shift+click behavior. anchor is the first index clicked, index is the last index clicked.
  */
-export function extendFromAnchor({ selection, anchor, index }: {selection: Selection, anchor?: number, index: number}): Selection {
+export function extendFromAnchor({ selection, anchor, index }: { selection: Selection, anchor?: number, index: number }): Selection {
   if (!isValidSelection(selection)) {
     throw new Error('Invalid selection')
   }
@@ -171,7 +171,7 @@ export function extendFromAnchor({ selection, anchor, index }: {selection: Selec
   }
 }
 
-export function toggleIndex({ selection, index }: {selection: Selection, index: number}): Selection {
+export function toggleIndex({ selection, index }: { selection: Selection, index: number }): Selection {
   if (!isValidIndex(index)) {
     throw new Error('Invalid index')
   }

--- a/test/selection.test.ts
+++ b/test/selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { areAllSelected, isSelected, isValidIndex, isValidRange, isValidSelection, toggleAll, toggleIndex } from '../src/selection.js'
+import { areAllSelected, extendToBound, isSelected, isValidIndex, isValidRange, isValidSelection, selectRange, toggleAll, toggleIndex, unselectRange } from '../src/selection.js'
 
 describe('an index', () => {
   test('is a positive integer', () => {
@@ -141,5 +141,70 @@ describe('toggleAll', () => {
   })
   test('should throw an error if the length is invalid', () => {
     expect(() => toggleAll({ selection: [], length: -1 })).toThrow('Invalid length')
+  })
+})
+
+describe('selectRange', () => {
+  test('should throw an error if the range is invalid', () => {
+    expect(() => selectRange({ selection: [], range: { start: -1, end: 0 } })).toThrow('Invalid range')
+  })
+  test('should throw an error if the selection is invalid', () => {
+    expect(() => selectRange({ selection: [{ start: 1, end: 0 }], range: { start: -1, end: 0 } })).toThrow('Invalid selection')
+  })
+  test('should add a new range if outside and separated from existing ranges', () => {
+    expect(selectRange({ selection: [], range: { start: 0, end: 1 } })).toEqual([{ start: 0, end: 1 }])
+    expect(selectRange({ selection: [{ start: 0, end: 1 }, { start: 4, end: 5 }], range: { start: 2, end: 3 } })).toEqual([{ start: 0, end: 1 }, { start: 2, end: 3 }, { start: 4, end: 5 }])
+  })
+  test('should merge with the previous and/or following ranges if adjacent', () => {
+    expect(selectRange({ selection: [{ start: 0, end: 1 }], range: { start: 1, end: 2 } })).toEqual([{ start: 0, end: 2 }])
+    expect(selectRange({ selection: [{ start: 1, end: 2 }], range: { start: 0, end: 1 } })).toEqual([{ start: 0, end: 2 }])
+    expect(selectRange({ selection: [{ start: 0, end: 1 }, { start: 2, end: 3 }], range: { start: 1, end: 2 } })).toEqual([{ start: 0, end: 3 }])
+  })
+})
+
+describe('unselectRange', () => {
+  test('should throw an error if the range is invalid', () => {
+    expect(() => unselectRange({ selection: [], range: { start: -1, end: 0 } })).toThrow('Invalid range')
+  })
+  test('should throw an error if the selection is invalid', () => {
+    expect(() => unselectRange({ selection: [{ start: 1, end: 0 }], range: { start: -1, end: 0 } })).toThrow('Invalid selection')
+  })
+  test('should remove the range if it exists', () => {
+    expect(unselectRange({ selection: [{ start: 0, end: 1 }], range: { start: 0, end: 1 } })).toEqual([])
+    expect(unselectRange({ selection: [{ start: 0, end: 1 }, { start: 2, end: 3 }], range: { start: 0, end: 1 } })).toEqual([{ start: 2, end: 3 }])
+    expect(unselectRange({ selection: [{ start: 0, end: 1 }, { start: 2, end: 3 }], range: { start: 2, end: 3 } })).toEqual([{ start: 0, end: 1 }])
+  })
+  test('should split the range if it is inside', () => {
+    expect(unselectRange({ selection: [{ start: 0, end: 3 }], range: { start: 1, end: 2 } })).toEqual([{ start: 0, end: 1 }, { start: 2, end: 3 }])
+  })
+  test('should do nothing if the range does not intersect with the selection', () => {
+    expect(unselectRange({ selection: [{ start: 0, end: 1 }], range: { start: 2, end: 3 } })).toEqual([{ start: 0, end: 1 }])
+    expect(unselectRange({ selection: [{ start: 0, end: 1 }, { start: 4, end: 5 }], range: { start: 2, end: 3 } })).toEqual([{ start: 0, end: 1 }, { start: 4, end: 5 }])
+  })
+})
+
+describe('toggleBeextendToBoundtweenBounds', () => {
+  test('should throw an error if the selection is invalid', () => {
+    expect(() => extendToBound({ selection: [{ start: 1, end: 0 }], bound1: 0, bound2: 1 })).toThrow('Invalid selection')
+  })
+  test('does nothing if the first bound is undefined', () => {
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound2: 1 })).toEqual([{ start: 0, end: 1 }])
+  })
+  test('does nothing if the bounds are the same', () => {
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 0, bound2: 0 })).toEqual([{ start: 0, end: 1 }])
+  })
+  test('should throw an error if the bounds are invalid', () => {
+    expect(() => extendToBound({ selection: [], bound1: -1, bound2: 0 })).toThrow('Invalid index')
+    expect(() => extendToBound({ selection: [], bound1: 0, bound2: -1 })).toThrow('Invalid index')
+  })
+  test('should select the range between the bounds (inclusive) if bound1 was selected', () => {
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 0, bound2: 1 })).toEqual([{ start: 0, end: 2 }])
+    expect(extendToBound({ selection: [{ start: 1, end: 2 }], bound1: 1, bound2: 0 })).toEqual([{ start: 0, end: 2 }])
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }, { start: 3, end: 4 }], bound1: 0, bound2: 5 })).toEqual([{ start: 0, end: 6 }])
+  })
+  test('should unselect the range between the bounds (inclusive) if bound1 was not selected', () => {
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 2, bound2: 3 })).toEqual([{ start: 0, end: 1 }])
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 2, bound2: 0 })).toEqual([])
+    expect(extendToBound({ selection: [{ start: 0, end: 1 }, { start: 3, end: 4 }], bound1: 2, bound2: 3 })).toEqual([{ start: 0, end: 1 }])
   })
 })

--- a/test/selection.test.ts
+++ b/test/selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { areAllSelected, extendToBound, isSelected, isValidIndex, isValidRange, isValidSelection, selectRange, toggleAll, toggleIndex, unselectRange } from '../src/selection.js'
+import { areAllSelected, extendFromAnchor, isSelected, isValidIndex, isValidRange, isValidSelection, selectRange, toggleAll, toggleIndex, unselectRange } from '../src/selection.js'
 
 describe('an index', () => {
   test('is a positive integer', () => {
@@ -183,28 +183,28 @@ describe('unselectRange', () => {
   })
 })
 
-describe('toggleBeextendToBoundtweenBounds', () => {
+describe('extendFromAnchor', () => {
   test('should throw an error if the selection is invalid', () => {
-    expect(() => extendToBound({ selection: [{ start: 1, end: 0 }], bound1: 0, bound2: 1 })).toThrow('Invalid selection')
+    expect(() => extendFromAnchor({ selection: [{ start: 1, end: 0 }], anchor: 0, index: 1 })).toThrow('Invalid selection')
   })
-  test('does nothing if the first bound is undefined', () => {
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound2: 1 })).toEqual([{ start: 0, end: 1 }])
+  test('does nothing if the anchor is undefined', () => {
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }], index: 1 })).toEqual([{ start: 0, end: 1 }])
   })
-  test('does nothing if the bounds are the same', () => {
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 0, bound2: 0 })).toEqual([{ start: 0, end: 1 }])
+  test('does nothing if the anchor and the index are the same', () => {
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }], anchor: 0, index: 0 })).toEqual([{ start: 0, end: 1 }])
   })
-  test('should throw an error if the bounds are invalid', () => {
-    expect(() => extendToBound({ selection: [], bound1: -1, bound2: 0 })).toThrow('Invalid index')
-    expect(() => extendToBound({ selection: [], bound1: 0, bound2: -1 })).toThrow('Invalid index')
+  test('should throw an error if the anchor or the index are invalid', () => {
+    expect(() => extendFromAnchor({ selection: [], anchor: -1, index: 0 })).toThrow('Invalid index')
+    expect(() => extendFromAnchor({ selection: [], anchor: 0, index: -1 })).toThrow('Invalid index')
   })
-  test('should select the range between the bounds (inclusive) if bound1 was selected', () => {
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 0, bound2: 1 })).toEqual([{ start: 0, end: 2 }])
-    expect(extendToBound({ selection: [{ start: 1, end: 2 }], bound1: 1, bound2: 0 })).toEqual([{ start: 0, end: 2 }])
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }, { start: 3, end: 4 }], bound1: 0, bound2: 5 })).toEqual([{ start: 0, end: 6 }])
+  test('should select the range between the bounds (inclusive) if anchor was selected', () => {
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }], anchor: 0, index: 1 })).toEqual([{ start: 0, end: 2 }])
+    expect(extendFromAnchor({ selection: [{ start: 1, end: 2 }], anchor: 1, index: 0 })).toEqual([{ start: 0, end: 2 }])
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }, { start: 3, end: 4 }], anchor: 0, index: 5 })).toEqual([{ start: 0, end: 6 }])
   })
-  test('should unselect the range between the bounds (inclusive) if bound1 was not selected', () => {
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 2, bound2: 3 })).toEqual([{ start: 0, end: 1 }])
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }], bound1: 2, bound2: 0 })).toEqual([])
-    expect(extendToBound({ selection: [{ start: 0, end: 1 }, { start: 3, end: 4 }], bound1: 2, bound2: 3 })).toEqual([{ start: 0, end: 1 }])
+  test('should unselect the range between the bounds (inclusive) if anchor was not selected', () => {
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }], anchor: 2, index: 3 })).toEqual([{ start: 0, end: 1 }])
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }], anchor: 2, index: 0 })).toEqual([])
+    expect(extendFromAnchor({ selection: [{ start: 0, end: 1 }, { start: 3, end: 4 }], anchor: 2, index: 3 })).toEqual([{ start: 0, end: 1 }])
   })
 })


### PR DESCRIPTION
Select a range of rows using shift+click. It extends a selection/deselection from an anchor (the last row selected or unselected with a click). I think it's the most natural behavior, and it seems to work well.

I could refactor the code (with confidence, thanks to the unit tests) so that toggling a row selection is a particular case of the most general selection/deselection of a range.

[Screencast From 2025-01-07 14-14-58.webm](https://github.com/user-attachments/assets/076c07f3-c371-4f2b-a4e9-a5d80b14843c)
