### PR TITLE
Fix row numbers in the left column + add tests

### DIFF
--- a/src/HighTable.css
+++ b/src/HighTable.css
@@ -56,7 +56,7 @@
   cursor: default;
   width: 0;
 }
-.table tbody tr:first-child td {
+.table tbody tr:first-child td, .table tbody tr:first-child th {
   border-top: 1px solid transparent;
 }
 
@@ -89,7 +89,7 @@
 }
 
 /* row numbers */
-.table td:first-child {
+.table th:first-child {
   background-color: #eaeaeb;
   border-right: 1px solid #ddd;
   color: #888;
@@ -104,23 +104,23 @@
   width: 32px;
   cursor: pointer;
 }
-.table td:first-child span {
+.table th:first-child span {
   display: inline;
 }
-.table td:first-child input {
+.table th:first-child input {
   display: none;
 }
-.selectable td:first-child:hover span, .selectable tr.selected td:first-child span {
+.selectable th:first-child:hover span, .selectable tr.selected th:first-child span {
   display: none;
 }
-.selectable td:first-child:hover input, .selectable tr.selected td:first-child input {
+.selectable th:first-child:hover input, .selectable tr.selected th:first-child input {
   display: inline;
   cursor: pointer;
 }
 .selectable tr.selected {
   background-color: #fbf7bf;
 }
-.selectable tr.selected td:first-child {
+.selectable tr.selected th:first-child {
   background-color: #f1edbb;
 }
 
@@ -175,7 +175,7 @@
 }
 
 /* pending table state */
-.table th::before {
+.table thead th::before {
   content: '';
   position: absolute;
   top: 0;
@@ -185,7 +185,7 @@
   background-color: #706fb1;
   z-index: 100;
 }
-.pending .table th::before {
+.pending .table thead th::before {
   animation: shimmer 2s infinite linear;
 }
 @keyframes shimmer {

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -278,7 +278,7 @@ export default function HighTable({
    *
    * @param value cell value
    * @param col column index
-   * @param row row index. Can be undefined.
+   * @param row row index. If undefined, onDoubleClickCell and onMouseDownCell will not be called.
    */
   function Cell(value: any, col: number, row?: number): ReactNode {
     // render as truncated text

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -397,7 +397,7 @@ export default function HighTable({
                     /// TODO(SL): we might want to show two columns: one for the tableIndex (for selection) and one for the dataIndex (to refer to the original data ids)
                     rowLabel(dataIndex)
                   }</span>
-                  <input type='checkbox' checked={isSelected({ selection, index: tableIndex })} />
+                  <input type='checkbox' checked={isSelected({ selection, index: tableIndex })} readOnly={true} />
                 </th>
                 {data.header.map((col, colIndex) =>
                   Cell(row[col], colIndex, dataIndex)
@@ -422,7 +422,7 @@ export default function HighTable({
     </div>
     <div className='table-corner' style={cornerStyle} onClick={() => selectable && dispatch({ type: 'SET_SELECTION', selection: toggleAll({ selection, length: rows.length }), anchor: undefined })}>
       <span>&nbsp;</span>
-      <input type='checkbox' checked={areAllSelected({ selection, length: rows.length })} />
+      <input type='checkbox' checked={areAllSelected({ selection, length: rows.length })} readOnly={true} />
     </div>
     <div className='mock-row-label' style={cornerStyle}>&nbsp;</div>
   </div>

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -356,8 +356,9 @@ export default function HighTable({
     <div className='table-scroll' ref={scrollRef}>
       <div style={{ height: `${scrollHeight}px` }}>
         <table
-          aria-colcount={data.header.length}
-          aria-rowcount={data.numRows}
+          aria-readonly={true}
+          aria-colcount={data.header.length + 1 /* don't forget the selection column */}
+          aria-rowcount={data.numRows + 1 /* don't forget the header row */}
           className={`table${data.sortable ? ' sortable' : ''}`}
           ref={tableRef}
           role='grid'
@@ -375,26 +376,29 @@ export default function HighTable({
           <tbody>
             {prePadding.map((_, prePaddingIndex) => {
               const tableIndex = startIndex - prePadding.length + prePaddingIndex
-              return <tr key={tableIndex}>
-                <td style={cornerStyle}>
+              return <tr key={tableIndex} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} >
+                <th scope="row" style={cornerStyle}>
                   {
                     /// TODO(SL): if the data is sorted, this sequence of row labels is incorrect and might include duplicate
                     /// labels with respect to the next slice of rows. Better to hide this number if the data is sorted?
                     rowLabel(tableIndex)
                   }
-                </td>
+                </th>
               </tr>
             })}
             {rows.map((row, sliceIndex) => {
               const { tableIndex, dataIndex } = getRowIndexes(sliceIndex)
-              return <tr key={tableIndex} title={rowError(row, dataIndex)} className={isSelected({ selection, index: tableIndex }) ? 'selected' : ''}>
-                <td style={cornerStyle} onClick={event => onRowNumberClick({ useAnchor: event.shiftKey, tableIndex })}>
+              return <tr key={tableIndex} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} title={rowError(row, dataIndex)}
+                className={isSelected({ selection, index: tableIndex }) ? 'selected' : ''}
+                aria-selected={isSelected({ selection, index: tableIndex })}
+              >
+                <th scope="row" style={cornerStyle} onClick={event => onRowNumberClick({ useAnchor: event.shiftKey, tableIndex })}>
                   <span>{
                     /// TODO(SL): we might want to show two columns: one for the tableIndex (for selection) and one for the dataIndex (to refer to the original data ids)
                     rowLabel(dataIndex)
                   }</span>
                   <input type='checkbox' checked={isSelected({ selection, index: tableIndex })} />
-                </td>
+                </th>
                 {data.header.map((col, colIndex) =>
                   Cell(row[col], colIndex, dataIndex)
                 )}
@@ -402,14 +406,14 @@ export default function HighTable({
             })}
             {postPadding.map((_, postPaddingIndex) => {
               const tableIndex = startIndex + rows.length + postPaddingIndex
-              return <tr key={tableIndex}>
-                <td style={cornerStyle}>
+              return <tr key={tableIndex} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} >
+                <th scope="row" style={cornerStyle} >
                   {
                     /// TODO(SL): if the data is sorted, this sequence of row labels is incorrect and might include duplicate
                     /// labels with respect to the previous slice of rows. Better to hide this number if the data is sorted?
                     rowLabel(tableIndex)
                   }
-                </td>
+                </th>
               </tr>
             })}
           </tbody>

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -107,6 +107,11 @@ const initialState: State = {
   selection: [],
 }
 
+function rowLabel(rowIndex: number): string {
+  // rowIndex + 1 because the displayed row numbers are 1-based
+  return (rowIndex + 1).toLocaleString()
+}
+
 /**
  * Render a table with streaming rows on demand from a DataFrame.
  */
@@ -258,13 +263,6 @@ export default function HighTable({
       tableControl?.publisher.unsubscribe(dispatch)
     }
   }, [tableControl])
-
-  const rowLabel = useCallback((rowIndex: number): string => {
-    // rowIndex + 1 because the displayed row numbers are 1-based
-    return (rowIndex + 1).toLocaleString()
-  }, [
-    // no dependencies, but we could add a setting to allow 0-based row numbers
-  ])
 
   /**
    * Validate row length

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -362,19 +362,18 @@ export default function HighTable({
           <tbody>
             {prePadding.map((_, prePaddingIndex) => {
               const tableIndex = startIndex - prePadding.length + prePaddingIndex
-              return <tr key={tableIndex /* it's not a useful React key */} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} >
+              return <tr key={tableIndex} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} >
                 <th scope="row" style={cornerStyle}>
                   {
-                    /// TODO(SL): if the data is sorted, this sequence of row labels is incorrect and might include duplicate
-                    /// labels with respect to the next slice of rows. Better to hide this number if the data is sorted?
-                    rowLabel(tableIndex)
+                    // If the data is sorted, we don't know the previous row indexes
+                    orderBy === undefined ? rowLabel(tableIndex) : ''
                   }
                 </th>
               </tr>
             })}
             {rows.map((row, sliceIndex) => {
               const tableIndex = startIndex + sliceIndex
-              return <tr key={tableIndex /* it's not a useful React key */} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} title={rowError(row)}
+              return <tr key={tableIndex} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} title={rowError(row)}
                 className={isSelected({ selection, index: tableIndex }) ? 'selected' : ''}
                 aria-selected={isSelected({ selection, index: tableIndex })}
               >
@@ -389,12 +388,11 @@ export default function HighTable({
             })}
             {postPadding.map((_, postPaddingIndex) => {
               const tableIndex = startIndex + rows.length + postPaddingIndex
-              return <tr key={tableIndex /* it's not a useful React key */} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} >
+              return <tr key={tableIndex} aria-rowindex={tableIndex + 2 /* 1-based + the header row */} >
                 <th scope="row" style={cornerStyle} >
                   {
-                    /// TODO(SL): if the data is sorted, this sequence of row labels is incorrect and might include duplicate
-                    /// labels with respect to the previous slice of rows. Better to hide this number if the data is sorted?
-                    rowLabel(tableIndex)
+                    // If the data is sorted, we don't know the next row indexes
+                    orderBy === undefined ? rowLabel(tableIndex) : ''
                   }
                 </th>
               </tr>

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -270,7 +270,7 @@ export default function HighTable({
    * Validate row length
    */
   function rowError(row?: Row): string | undefined {
-    if (!row) return 'Pending'
+    if (!row) return 'Loading the row contents...'
     const numKeys = Object.keys(row).length - 1 // exclude __index__
     if (numKeys > 0 && numKeys !== data.header.length) {
       return `Row ${rowLabel(row.__index__)} length ${numKeys} does not match header length ${data.header.length}`

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -49,7 +49,7 @@ type State = {
   columnWidths: Array<number | undefined> // width of each column
   invalidate: boolean // true if the data must be fetched again
   hasCompleteRow: boolean // true if at least one row is fully resolved (all of its cells)
-  rows: Row[] // slice of the virtual table rows (sorted rows) to render as HTML. It might contain incomplete rows, and __index__ might be missing.
+  rows: Row[] // slice of the virtual table rows (sorted rows) to render as HTML. It might contain incomplete rows. Rows are expected to include __index__ if sorted.
   startIndex: number // offset of the slice of sorted rows to render (rows[0] is the startIndex'th sorted row)
   orderBy?: string // column name to sort by
   selection: Selection // rows selection. The values are indexes of the virtual table (sorted rows), and thus depend on the order.

--- a/src/TableHeader.tsx
+++ b/src/TableHeader.tsx
@@ -146,10 +146,11 @@ export default function TableHeader({
   const memoizedStyles = useMemo(() => columnWidths.map(cellStyle), [columnWidths])
 
   return <thead>
-    <tr>
+    <tr aria-rowindex={1}>
       <th><span /></th>
       {header.map((columnHeader, columnIndex) =>
         <th
+          scope="col"
           aria-sort={orderBy === columnHeader ? 'ascending' : undefined}
           className={orderBy === columnHeader ? 'orderby' : undefined}
           key={columnIndex}

--- a/src/dataframe.ts
+++ b/src/dataframe.ts
@@ -26,8 +26,8 @@ export interface DataFrame {
   sortable?: boolean
 }
 
-export function resolvableRow(header: string[]): { [key: string]: ResolvablePromise<any> } & { __index__: ResolvablePromise<number> } {
-  return Object.fromEntries([...header.map(key => [key, resolvablePromise<any>()]), ['__index__', resolvablePromise<number>()]])
+export function resolvableRow(header: string[]): { [key: string]: ResolvablePromise<any> } {
+  return Object.fromEntries(header.map(key => [key, resolvablePromise<any>()]))
 }
 
 /**

--- a/src/dataframe.ts
+++ b/src/dataframe.ts
@@ -118,7 +118,8 @@ export function sortableDataFrame(data: DataFrame): DataFrame {
     rows(start: number, end: number, orderBy?: string): AsyncRow[] | Promise<Row[]> {
       if (orderBy) {
         if (!data.header.includes(orderBy)) {
-          /// TODO(SL): should we allow '__index__'?
+          // '__index__' is not allowed, and it would not make sense anyway
+          // as it's the same as orderBy=undefined, since we only support ascending order
           throw new Error(`Invalid orderBy field: ${orderBy}`)
         }
         if (!all) {

--- a/src/dataframe.ts
+++ b/src/dataframe.ts
@@ -26,8 +26,8 @@ export interface DataFrame {
   sortable?: boolean
 }
 
-export function resolvableRow(header: string[]): { [key: string]: ResolvablePromise<any> } {
-  return Object.fromEntries(header.map(key => [key, resolvablePromise<any>()]))
+export function resolvableRow(header: string[]): { [key: string]: ResolvablePromise<any> } & { __index__: ResolvablePromise<number> } {
+  return Object.fromEntries([...header.map(key => [key, resolvablePromise<any>()]), ['__index__', resolvablePromise<number>()]])
 }
 
 /**

--- a/test/HighTable.test.tsx
+++ b/test/HighTable.test.tsx
@@ -10,7 +10,6 @@ describe('HighTable', () => {
     numRows: 100,
     rows: vi.fn((start, end) => Promise.resolve(
       Array.from({ length: end - start }, (_, index) => ({
-        __index__: index + start,
         ID: index + start,
         Name: 'Name ' + (index + start),
         Age: 20 + index % 50,
@@ -99,7 +98,6 @@ describe('When sorted, HighTable', () => {
     numRows: 1000,
     rows: (start: number, end: number) => Promise.resolve(
       Array.from({ length: end - start }, (_, index) => ({
-        __index__: index + start,
         ID: 'row ' + (index + start),
         Count: 1000 - start - index,
       }))

--- a/test/dataframe.test.ts
+++ b/test/dataframe.test.ts
@@ -3,7 +3,7 @@ import {
   AsyncRow, DataFrame, Row, arrayDataFrame, awaitRows, resolvablePromise, sortableDataFrame, wrapPromise,
 } from '../src/dataframe.js'
 
-export function wrapObject(obj: Row): AsyncRow {
+function wrapObject(obj: Row): AsyncRow {
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => [key, wrapPromise(value)])
   )

--- a/test/dataframe.test.ts
+++ b/test/dataframe.test.ts
@@ -4,10 +4,9 @@ import {
 } from '../src/dataframe.js'
 
 export function wrapObject(obj: Row): AsyncRow {
-  return Object.fromEntries([
-    ['__index__', wrapPromise(obj.__index__)],
-    ...Object.entries(obj).filter(([key]) => key !== '__index__').map(([key, value]) => [key, wrapPromise(value)]),
-  ])
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, wrapPromise(value)])
+  )
 }
 
 describe('resolvablePromise', () => {
@@ -37,7 +36,7 @@ describe('sortableDataFrame', () => {
     { id: 1, name: 'Alice', age: 30 },
     { id: 2, name: 'Bob', age: 20 },
     { id: 4, name: 'Dani', age: 20 },
-  ].map((d, i) => ({ ...d, __index__: i }))
+  ]
 
   const dataFrame: DataFrame = {
     header: ['id', 'name', 'age'],
@@ -63,9 +62,9 @@ describe('sortableDataFrame', () => {
   it('should return unsorted data when orderBy is not provided', async () => {
     const rows = await awaitRows(sortableDf.rows(0, 3))
     expect(rows).toEqual([
-      { id: 3, name: 'Charlie', age: 25, __index__: 0 },
-      { id: 1, name: 'Alice', age: 30, __index__: 1 },
-      { id: 2, name: 'Bob', age: 20, __index__: 2 },
+      { id: 3, name: 'Charlie', age: 25 },
+      { id: 1, name: 'Alice', age: 30 },
+      { id: 2, name: 'Bob', age: 20 },
     ])
   })
 
@@ -103,7 +102,7 @@ describe('arrayDataFrame', () => {
     { id: 1, name: 'Alice', age: 30 },
     { id: 2, name: 'Bob', age: 25 },
     { id: 3, name: 'Charlie', age: 35 },
-  ].map((d, i) => ({ ...d, __index__: i }))
+  ]
 
   it('should create a DataFrame with correct header and numRows', () => {
     const df = arrayDataFrame(testData)
@@ -122,8 +121,8 @@ describe('arrayDataFrame', () => {
     const df = arrayDataFrame(testData)
     const rows = await df.rows(0, 2)
     expect(rows).toEqual([
-      { id: 1, name: 'Alice', age: 30, __index__: 0 },
-      { id: 2, name: 'Bob', age: 25, __index__: 1 },
+      { id: 1, name: 'Alice', age: 30 },
+      { id: 2, name: 'Bob', age: 25 },
     ])
   })
 

--- a/test/dataframe.test.ts
+++ b/test/dataframe.test.ts
@@ -3,7 +3,7 @@ import {
   AsyncRow, DataFrame, Row, arrayDataFrame, awaitRows, resolvablePromise, sortableDataFrame, wrapPromise,
 } from '../src/dataframe.js'
 
-function wrapObject(obj: Row): AsyncRow {
+export function wrapObject(obj: Row): AsyncRow {
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => [key, wrapPromise(value)])
   )

--- a/test/rowCache.test.ts
+++ b/test/rowCache.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
-import { Row, awaitRows } from '../src/dataframe.js'
+import { AsyncRow, awaitRows } from '../src/dataframe.js'
 import { rowCache } from '../src/rowCache.js'
+import { wrapObject } from './dataframe.test.js'
 
 // Mock DataFrame
 function makeDf() {
   return {
     header: ['id'],
     numRows: 10,
-    rows: vi.fn((start: number, end: number): Row[] => {
+    rows: vi.fn((start: number, end: number): AsyncRow[] => {
       return new Array(end - start).fill(null)
-        .map((_, index) => ({ id: start + index }))
+        .map((_, index) => wrapObject({
+          __index__: start + index,
+        }))
     }),
   }
 }
@@ -19,7 +22,7 @@ describe('rowCache', () => {
     const df = makeDf()
     const dfCached = rowCache(df)
     const rows = await awaitRows(dfCached.rows(0, 3))
-    expect(rows).toEqual([{ id: 0 }, { id: 1 }, { id: 2 }])
+    expect(rows).toEqual([{ __index__: 0 }, { __index__: 1 }, { __index__: 2 }])
     expect(df.rows).toHaveBeenCalledTimes(1)
     expect(df.rows).toHaveBeenCalledWith(0, 3, undefined)
   })
@@ -30,13 +33,13 @@ describe('rowCache', () => {
 
     // Initial fetch to cache rows
     const rowsPre = await awaitRows(dfCached.rows(3, 6))
-    expect(rowsPre).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }])
+    expect(rowsPre).toEqual([{ __index__: 3 }, { __index__: 4 }, { __index__: 5 }])
     expect(df.rows).toHaveBeenCalledTimes(1)
     expect(df.rows).toHaveBeenCalledWith(3, 6, undefined)
 
     // Subsequent fetch should use cache
     const rowsPost = await awaitRows(dfCached.rows(3, 6))
-    expect(rowsPost).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }])
+    expect(rowsPost).toEqual([{ __index__: 3 }, { __index__: 4 }, { __index__: 5 }])
     expect(df.rows).toHaveBeenCalledTimes(1)
   })
 
@@ -54,7 +57,7 @@ describe('rowCache', () => {
     const adjacentRows = await awaitRows(dfCached.rows(0, 6))
 
     expect(adjacentRows).toEqual([
-      { id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 },
+      { __index__: 0 }, { __index__: 1 }, { __index__: 2 }, { __index__: 3 }, { __index__: 4 }, { __index__: 5 },
     ])
     expect(df.rows).toHaveBeenCalledTimes(2)
   })
@@ -70,7 +73,7 @@ describe('rowCache', () => {
     // Fetch combined block
     const gapRows = await awaitRows(dfCached.rows(0, 6))
     expect(gapRows).toEqual([
-      { id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 },
+      { __index__: 0 }, { __index__: 1 }, { __index__: 2 }, { __index__: 3 }, { __index__: 4 }, { __index__: 5 },
     ])
     expect(df.rows).toHaveBeenCalledTimes(3)
     expect(df.rows).toHaveBeenCalledWith(2, 4, undefined)
@@ -86,7 +89,7 @@ describe('rowCache', () => {
     // Fetch overlapping block
     const overlappingRows = await awaitRows(dfCached.rows(8, 11))
     expect(overlappingRows).toEqual([
-      { id: 8 }, { id: 9 }, { id: 10 },
+      { __index__: 8 }, { __index__: 9 }, { __index__: 10 },
     ])
     expect(df.rows).toHaveBeenCalledTimes(2)
     expect(df.rows).toHaveBeenCalledWith(9, 11, undefined)


### PR DESCRIPTION
Add `__index__: number` as a mandatory field of the rows. It's a breaking change, but when data is sorted, we need to be sure (and the types should reflect it) that the row index is provided to:
- show the row number in the left column
- be able to show the cell content when double clicking

Two alternatives:
- force `__index__` in the rows only when orderBy is not undefined, because otherwise we already have the index. It's what is implemented in the helper function `sortableDataFrame`, and we could simply add type with function overloads. It would be a breaking change anyway since we don't force anything at the moment, but possibly less impactful.
- don't break things, and simply remove features (no row number displayed in the left column, and no double click/mouse down callbacks) if data is sorted and no index is provided

---

Also in this PR: 

- I added some aria attributes as testing-library primarily relies on roles and accessible information (by opposition to the specific organization of the DOM), and as adopting its way of thinking helps build a more accessible component
- I added tests on column sort and mouse double-click, to be sure the correct row index is sent.
- [Breaking (the CSS)] I changed the left cells (row numbers) from `<td>` to `<th>` as it's semantically better, I think. But we can revert if it's better to avoid breaking the styles.
