### PR TITLE
only support rows(): AsyncRow[]

### DIFF
--- a/src/rowCache.ts
+++ b/src/rowCache.ts
@@ -1,4 +1,4 @@
-import { AsyncRow, DataFrame, asyncRows } from './dataframe.js'
+import { AsyncRow, DataFrame } from './dataframe.js'
 
 /**
  * Wrap a dataframe with cached rows.
@@ -32,8 +32,7 @@ export function rowCache(df: DataFrame): DataFrame {
           }
         } else if (blockStart !== undefined) {
           const blockEnd = i
-          const numRows = blockEnd - blockStart
-          const futureRows = asyncRows(df.rows(blockStart, blockEnd, orderBy), numRows, df.header)
+          const futureRows = df.rows(blockStart, blockEnd, orderBy)
           for (let j = 0; j < blockEnd - blockStart; j++) {
             cache[blockStart + j] = futureRows[j]
           }

--- a/test/HighTable.test.tsx
+++ b/test/HighTable.test.tsx
@@ -1,42 +1,46 @@
 import { act, fireEvent, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { sortableDataFrame } from '../src/dataframe.js'
+import { sortableDataFrame, wrapPromise } from '../src/dataframe.js'
 import HighTable from '../src/HighTable.js'
 import { render } from './userEvent.js'
 
 const data = {
   header: ['ID', 'Count'],
   numRows: 1000,
-  rows: (start: number, end: number) => Promise.resolve(
-    Array.from({ length: end - start }, (_, index) => ({
-      ID: 'row ' + (index + start),
-      Count: 1000 - start - index,
-    }))
-  ),
+  rows: (start: number, end: number) => Array.from({ length: end - start }, (_, index) => ({
+    index: wrapPromise(index + start),
+    cells: {
+      ID: wrapPromise('row ' + (index + start)),
+      Count: wrapPromise(1000 - start - index),
+    },
+  })),
 }
 
 const otherData = {
   header: ['ID', 'Count'],
   numRows: 1000,
-  rows: (start: number, end: number) => Promise.resolve(
-    Array.from({ length: end - start }, (_, index) => ({
-      ID: 'other ' + (index + start),
-      Count: 1000 - start - index,
-    }))
-  ),
+  rows: (start: number, end: number) => Array.from({ length: end - start }, (_, index) => ({
+    index: wrapPromise(index + start),
+    cells: {
+      ID: wrapPromise('other ' + (index + start)),
+      Count: wrapPromise(1000 - start - index),
+    },
+  })),
 }
 
 describe('HighTable', () => {
   const mockData = {
     header: ['ID', 'Name', 'Age'],
     numRows: 100,
-    rows: vi.fn((start, end) => Promise.resolve(
-      Array.from({ length: end - start }, (_, index) => ({
-        ID: index + start,
-        Name: 'Name ' + (index + start),
-        Age: 20 + index % 50,
-      }))
-    )),
+    rows: vi.fn((start, end) => Array.from({ length: end - start }, (_, index) => ({
+      index: wrapPromise(index + start),
+      cells: {
+        ID: wrapPromise(index + start),
+        Name: wrapPromise('Name ' + (index + start)),
+        Age: wrapPromise(20 + index % 50),
+      },
+    }))
+    ),
   }
 
   beforeEach(() => {
@@ -62,7 +66,7 @@ describe('HighTable', () => {
   })
 
   it('creates the rows after having fetched the data', async () => {
-    const { findByRole, queryByText, queryByRole } = render(<HighTable data={mockData}/>)
+    const { findByRole, queryByRole } = render(<HighTable data={mockData}/>)
     expect(queryByRole('cell', { name: 'Name 0' })).toBeNull()
     // await because we have to wait for the data to be fetched first
     await findByRole('cell', { name: 'Name 0' })
@@ -180,9 +184,6 @@ describe('When sorted, HighTable', () => {
 })
 
 describe('in controlled selection state (selection and onSelection props), ', () => {
-
-
-
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -324,9 +325,6 @@ describe('in controlled selection state (selection and onSelection props), ', ()
 })
 
 describe('in controlled selection state, read-only (selection prop), ', () => {
-
-
-
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -400,9 +398,6 @@ describe('in controlled selection state, read-only (selection prop), ', () => {
 })
 
 describe('in uncontrolled selection state (onSelection prop), ', () => {
-
-
-
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -488,9 +483,6 @@ describe('in uncontrolled selection state (onSelection prop), ', () => {
 })
 
 describe('in disabled selection state (neither selection nor onSelection props), ', () => {
-
-
-
   beforeEach(() => {
     vi.clearAllMocks()
   })

--- a/test/dataframe.test.ts
+++ b/test/dataframe.test.ts
@@ -3,10 +3,13 @@ import {
   AsyncRow, DataFrame, Row, arrayDataFrame, awaitRows, resolvablePromise, sortableDataFrame, wrapPromise,
 } from '../src/dataframe.js'
 
-export function wrapObject(obj: Row): AsyncRow {
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [key, wrapPromise(value)])
-  )
+export function wrapObject({ index, cells }: Row): AsyncRow {
+  return {
+    index: wrapPromise(index),
+    cells: Object.fromEntries(
+      Object.entries(cells).map(([key, value]) => [key, wrapPromise(value)])
+    ),
+  }
 }
 
 describe('resolvablePromise', () => {
@@ -24,9 +27,9 @@ describe('resolvablePromise', () => {
 
 describe('awaitRows', () => {
   it('should resolve with a row', async () => {
-    const row = wrapObject({ id: 1, name: 'Alice', age: 30, __index__: 0 })
+    const row = wrapObject({ cells: { id: 1, name: 'Alice', age: 30 }, index: 0 })
     const result = await awaitRows([row])
-    expect(result).toEqual([{ id: 1, name: 'Alice', age: 30, __index__: 0 }])
+    expect(result).toEqual([{ cells: { id: 1, name: 'Alice', age: 30 }, index: 0 }])
   })
 })
 
@@ -36,7 +39,7 @@ describe('sortableDataFrame', () => {
     { id: 1, name: 'Alice', age: 30 },
     { id: 2, name: 'Bob', age: 20 },
     { id: 4, name: 'Dani', age: 20 },
-  ]
+  ].map((cells, index) => ({ cells, index }))
 
   const dataFrame: DataFrame = {
     header: ['id', 'name', 'age'],
@@ -65,24 +68,24 @@ describe('sortableDataFrame', () => {
       { id: 3, name: 'Charlie', age: 25 },
       { id: 1, name: 'Alice', age: 30 },
       { id: 2, name: 'Bob', age: 20 },
-    ])
+    ].map((cells, index) => ({ cells, index })))
   })
 
   it('should return data sorted by column "age"', async () => {
     const rows = await awaitRows(sortableDf.rows(0, 4, 'age'))
     expect(rows).toEqual([
-      { id: 2, name: 'Bob', age: 20, __index__: 2 },
-      { id: 4, name: 'Dani', age: 20, __index__: 3 },
-      { id: 3, name: 'Charlie', age: 25, __index__: 0 },
-      { id: 1, name: 'Alice', age: 30, __index__: 1 },
+      { index: 2, cells:{ id: 2, name: 'Bob', age: 20 } },
+      { index: 3, cells:{ id: 4, name: 'Dani', age: 20 } },
+      { index: 0, cells:{ id: 3, name: 'Charlie', age: 25 } },
+      { index: 1, cells:{ id: 1, name: 'Alice', age: 30 } },
     ])
   })
 
   it('should slice the sorted data correctly', async () => {
     const rows = await awaitRows(sortableDf.rows(1, 3, 'id'))
     expect(rows).toEqual([
-      { id: 2, name: 'Bob', age: 20, __index__: 2 },
-      { id: 3, name: 'Charlie', age: 25, __index__: 0 },
+      { index: 2, cells:{ id: 2, name: 'Bob', age: 20 } },
+      { index: 0, cells:{ id: 3, name: 'Charlie', age: 25 } },
     ])
   })
 
@@ -114,27 +117,27 @@ describe('arrayDataFrame', () => {
     const df = arrayDataFrame([])
     expect(df.header).toEqual([])
     expect(df.numRows).toBe(0)
-    await expect(df.rows(0, 1)).resolves.toEqual([])
+    await expect(awaitRows(df.rows(0, 1))).resolves.toEqual([])
   })
 
   it('should return correct rows for given range', async () => {
     const df = arrayDataFrame(testData)
-    const rows = await df.rows(0, 2)
+    const rows = await awaitRows(df.rows(0, 2))
     expect(rows).toEqual([
       { id: 1, name: 'Alice', age: 30 },
       { id: 2, name: 'Bob', age: 25 },
-    ])
+    ].map((cells, index) => ({ cells, index })))
   })
 
   it('should handle start index equal to end index', async () => {
     const df = arrayDataFrame(testData)
-    const rows = await df.rows(1, 1)
+    const rows = await awaitRows(df.rows(1, 1))
     expect(rows).toEqual([])
   })
 
   it('should return all rows when end index exceeds array length', async () => {
     const df = arrayDataFrame(testData)
-    const rows = await df.rows(0, 10)
-    expect(rows).toEqual(testData)
+    const rows = await awaitRows(df.rows(0, 10))
+    expect(rows).toEqual(testData.map((cells, index) => ({ cells, index })))
   })
 })

--- a/test/rowCache.test.ts
+++ b/test/rowCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { Row, awaitRows } from '../src/dataframe.js'
+import { AsyncRow, awaitRows, wrapPromise } from '../src/dataframe.js'
 import { rowCache } from '../src/rowCache.js'
 
 // Mock DataFrame
@@ -7,10 +7,16 @@ function makeDf() {
   return {
     header: ['id'],
     numRows: 10,
-    rows: vi.fn((start: number, end: number): Row[] => {
-      return new Array(end - start).fill(null)
-        .map((_, index) => ({ id: start + index }))
-    }),
+    rows: vi.fn((start: number, end: number): AsyncRow[] =>
+      new Array(end - start)
+        .fill(null)
+        .map((_, index) => ({
+          index: wrapPromise(start + index),
+          cells: {
+            id: wrapPromise(start + index),
+          },
+        }))
+    ),
   }
 }
 
@@ -19,7 +25,7 @@ describe('rowCache', () => {
     const df = makeDf()
     const dfCached = rowCache(df)
     const rows = await awaitRows(dfCached.rows(0, 3))
-    expect(rows).toEqual([{ id: 0 }, { id: 1 }, { id: 2 }])
+    expect(rows).toEqual([{ id: 0 }, { id: 1 }, { id: 2 }].map((cells, index) => ({ cells, index })))
     expect(df.rows).toHaveBeenCalledTimes(1)
     expect(df.rows).toHaveBeenCalledWith(0, 3, undefined)
   })
@@ -30,13 +36,13 @@ describe('rowCache', () => {
 
     // Initial fetch to cache rows
     const rowsPre = await awaitRows(dfCached.rows(3, 6))
-    expect(rowsPre).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }])
+    expect(rowsPre).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }].map((cells, index) => ({ cells, index: index + 3 })))
     expect(df.rows).toHaveBeenCalledTimes(1)
     expect(df.rows).toHaveBeenCalledWith(3, 6, undefined)
 
     // Subsequent fetch should use cache
     const rowsPost = await awaitRows(dfCached.rows(3, 6))
-    expect(rowsPost).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }])
+    expect(rowsPost).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }].map((cells, index) => ({ cells, index: index + 3 })))
     expect(df.rows).toHaveBeenCalledTimes(1)
   })
 
@@ -55,7 +61,7 @@ describe('rowCache', () => {
 
     expect(adjacentRows).toEqual([
       { id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 },
-    ])
+    ].map((cells, index) => ({ cells, index })))
     expect(df.rows).toHaveBeenCalledTimes(2)
   })
 
@@ -71,7 +77,7 @@ describe('rowCache', () => {
     const gapRows = await awaitRows(dfCached.rows(0, 6))
     expect(gapRows).toEqual([
       { id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 },
-    ])
+    ].map((cells, index) => ({ cells, index })))
     expect(df.rows).toHaveBeenCalledTimes(3)
     expect(df.rows).toHaveBeenCalledWith(2, 4, undefined)
   })
@@ -87,7 +93,7 @@ describe('rowCache', () => {
     const overlappingRows = await awaitRows(dfCached.rows(8, 11))
     expect(overlappingRows).toEqual([
       { id: 8 }, { id: 9 }, { id: 10 },
-    ])
+    ].map((cells, index) => ({ cells, index: index + 8 })))
     expect(df.rows).toHaveBeenCalledTimes(2)
     expect(df.rows).toHaveBeenCalledWith(9, 11, undefined)
   })


### PR DESCRIPTION
This PR is a breaking change in the dataframe's `rows` method, since it must return `AsyncRow[]`, instead of supporting two types: `AsyncRow[] | Promise<Row[]>`.

Also, I separate the index from the values to avoid collisions and make the code simpler:

```
type Cells = Record<string, any>

/**
 * A row where each cell is a resolved value.
 */
export interface Row {
  cells: Cells
  index: number
}
```
