### PR TITLE
use Promise.all

### DIFF
--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -276,12 +276,7 @@ export default function HighTable({
         }
 
         // Await all pending promises
-        for (const asyncRow of rowsChunk) {
-          for (const promise of [asyncRow.index, ...Object.values(asyncRow.cells)]) {
-            await promise
-            // TODO(SL): shouldn't it be await Promise.all([...]) to run them in parallel?
-          }
-        }
+        await Promise.all(rowsChunk.flatMap(asyncRow => [asyncRow.index, ...Object.values(asyncRow.cells)]))
 
         // if user scrolled while fetching, fetch again
         if (pendingUpdate.current) {


### PR DESCRIPTION
I think it's better:
- <strike>the promises run in parallel, not serially</strike>
- it raises faster (if it raises)