### PR TITLE
[wip] Promise to field in wrapped

### DIFF
--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -247,14 +247,14 @@ export default function HighTable({
           for (const asyncRow of rowsChunk) {
             const resolvedRow: PartialRow = { cells: {} }
             let isRowComplete = true
-            for (const [key, { resolved }] of Object.entries(asyncRow.cells)) {
-              if (resolved !== undefined) {
-                resolvedRow.cells[key] = resolved
+            for (const [key, wrappedPromise] of Object.entries(asyncRow.cells)) {
+              if ('resolved' in wrappedPromise) {
+                resolvedRow.cells[key] = wrappedPromise.resolved
               } else {
                 isRowComplete = false
               }
             }
-            if (asyncRow.index.resolved !== undefined) {
+            if ('resolved' in asyncRow.index) {
               resolvedRow.index = asyncRow.index.resolved
             } else {
               isRowComplete = false

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -248,13 +248,13 @@ export default function HighTable({
             const resolvedRow: PartialRow = { cells: {} }
             let isRowComplete = true
             for (const [key, wrappedPromise] of Object.entries(asyncRow.cells)) {
-              if ('resolved' in wrappedPromise) {
+              if (wrappedPromise.resolved !== undefined) {
                 resolvedRow.cells[key] = wrappedPromise.resolved
               } else {
                 isRowComplete = false
               }
             }
-            if ('resolved' in asyncRow.index) {
+            if (asyncRow.index.resolved !== undefined) {
               resolvedRow.index = asyncRow.index.resolved
             } else {
               isRowComplete = false

--- a/src/dataframe.ts
+++ b/src/dataframe.ts
@@ -2,20 +2,45 @@ import { wrapPromise } from './promise.js'
 import { AsyncRow, Cells, Row, asyncRows, awaitRows } from './row.js'
 
 /**
- * Streamable row data
+ * A DataFrame is a table of data with a header and rows.
  */
 export interface DataFrame {
+  /**
+   * an array of strings representing the column names.
+   */
   header: string[]
+  /**
+   * the total number of rows in the DataFrame.
+   */
   numRows: number
-  // Rows are 0-indexed, excludes the header, end is exclusive
-  // if orderBy is provided, start and end are applied to the sorted rows
+  /**
+   * get a slice of rows from the DataFrame.
+   *
+   * If sorted (orderBy is provided), the slice is applied to the sorted rows.
+   * Otherwise, the slice is applied to the original rows.
+   *
+   * The slice is 0-indexed and excludes the header.
+   *
+   * @param start the index of the first row to include.
+   * @param end the index of the first row to exclude.
+   * @param orderBy the column name to sort the rows by.
+   *
+   * @returns an array of AsyncRow objects (with wrapped promises for index and cells).
+   */
   rows(start: number, end: number, orderBy?: string): AsyncRow[]
+  /**
+   * whether the DataFrame is sortable.
+   */
   sortable?: boolean
 }
 
 /**
  * Wraps a DataFrame to make it sortable.
  * Requires fetching all rows to sort.
+ *
+ * @param data The DataFrame to make sortable.
+ *
+ * @returns A new DataFrame that can be sorted.
  */
 export function sortableDataFrame(data: DataFrame): DataFrame {
   if (data.sortable) return data // already sortable
@@ -28,6 +53,12 @@ export function sortableDataFrame(data: DataFrame): DataFrame {
         if (!data.header.includes(orderBy)) {
           throw new Error(`Invalid orderBy field: ${orderBy}`)
         }
+        // TODO(SL): ideas for optimization:
+        // 1. create the sorted index (index => index) if missing, by fetching only the column orderBy and sorting it
+        // 2. use the cached sorted index to fetch the rows at the right indexes
+        // Note: the index might an optional method of DataFrame: index(orderBy: string): Promise<{direct: number[], reverse: number[]}>
+        // with a default implementation here if not provided.
+        // Maybe use typed arrays for performance.
         if (!all) {
           // Fetch all rows
           all = awaitRows(data.rows(0, data.numRows))
@@ -48,6 +79,15 @@ export function sortableDataFrame(data: DataFrame): DataFrame {
   }
 }
 
+/**
+ * Create a dataframe from an array of rows.
+ *
+ * The header (column names) is created from the keys of the first row.
+ *
+ * @param data An array of rows.
+ *
+ * @returns DataFrame object.
+ */
 export function arrayDataFrame(data: Cells[]): DataFrame {
   if (!data.length) return { header: [], numRows: 0, rows: () => [] }
   return {

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -37,7 +37,7 @@ export function withResolvers<T>(): PromiseWithResolvers<T> {
 }
 
 export function resolvablePromise<T>(): ResolvablePromise<T> {
-  const w = withResolvers<T>()
-  const wrapped = wrapPromise(w.promise)
-  return Object.assign(wrapped, w)
+  const { promise, resolve, reject } = withResolvers<T>()
+  const wrapped = wrapPromise(promise)
+  return Object.assign(wrapped, { resolve, reject })
 }

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -7,34 +7,31 @@ export type WrappedPromise<T> = {
 export function wrapPromise<T>(promise: Promise<T>): WrappedPromise<T>
 export function wrapPromise<T>(resolved: T): WrappedPromise<T>
 export function wrapPromise<T>(input: Promise<T> | T): WrappedPromise<T> {
-  const wrappedPromise: WrappedPromise<T> = {
+  const wrapped: WrappedPromise<T> = {
     promise: input instanceof Promise ? input : Promise.resolve(input),
   }
-  // add resolved or rejected property to the wrapped promise
-  wrappedPromise.promise.then(resolved => {
-    wrappedPromise.resolved = resolved
-    wrappedPromise.rejected = undefined
+  // add resolved or rejected property to the wrapped object
+  wrapped.promise.then(resolved => {
+    wrapped.resolved = resolved
+    wrapped.rejected = undefined
     return resolved
   }).catch(rejected => {
-    wrappedPromise.resolved = undefined
-    wrappedPromise.rejected = rejected
+    wrapped.resolved = undefined
+    wrapped.rejected = rejected
     throw rejected
   })
-  return wrappedPromise
+  return wrapped
 }
 
 export type ResolvablePromise<T> = WrappedPromise<T> & PromiseWithResolvers<T>
 
 export function resolvablePromise<T>(): ResolvablePromise<T> {
-  // const promiseWithResolvers = Promise.withResolvers<T>()
   // Promise.withResolvers is too recent. Let's use the polyfill instead.
   let resolve: PromiseWithResolvers<T>['resolve']
   let reject: PromiseWithResolvers<T>['reject']
-  const promise = new Promise<T>((resolve_, reject_) => {
+  const wrapped = wrapPromise(new Promise<T>((resolve_, reject_) => {
     resolve = resolve_
     reject = reject_
-  })
-  const promiseWithResolvers = { promise, resolve: resolve!, reject: reject! }
-
-  return Object.assign(promiseWithResolvers, wrapPromise<T>(promiseWithResolvers.promise))
+  }))
+  return Object.assign(wrapped, { resolve: resolve!, reject: reject! })
 }

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -25,13 +25,19 @@ export function wrapPromise<T>(input: Promise<T> | T): WrappedPromise<T> {
 
 export type ResolvablePromise<T> = WrappedPromise<T> & PromiseWithResolvers<T>
 
-export function resolvablePromise<T>(): ResolvablePromise<T> {
-  // Promise.withResolvers is too recent. Let's use the polyfill instead.
-  let resolve: PromiseWithResolvers<T>['resolve']
-  let reject: PromiseWithResolvers<T>['reject']
-  const wrapped = wrapPromise(new Promise<T>((resolve_, reject_) => {
+// Promise.withResolvers is too recent. Let's use the polyfill instead.
+export function withResolvers<T>(): PromiseWithResolvers<T> {
+  let resolve!: PromiseWithResolvers<T>['resolve']
+  let reject!: PromiseWithResolvers<T>['reject']
+  const promise = new Promise<T>((resolve_, reject_) => {
     resolve = resolve_
     reject = reject_
-  }))
-  return Object.assign(wrapped, { resolve: resolve!, reject: reject! })
+  })
+  return { promise, resolve, reject }
+}
+
+export function resolvablePromise<T>(): ResolvablePromise<T> {
+  const w = withResolvers<T>()
+  const wrapped = wrapPromise(w.promise)
+  return Object.assign(wrapped, w)
 }

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -10,7 +10,7 @@ export function wrapPromise<T>(input: Promise<T> | T): WrappedPromise<T> {
   const wrappedPromise: WrappedPromise<T> = {
     promise: input instanceof Promise ? input : Promise.resolve(input),
   }
-  // add resolved or rejected property to the asyncValue
+  // add resolved or rejected property to the wrapped promise
   wrappedPromise.promise.then(resolved => {
     wrappedPromise.resolved = resolved
     wrappedPromise.rejected = undefined
@@ -26,6 +26,15 @@ export function wrapPromise<T>(input: Promise<T> | T): WrappedPromise<T> {
 export type ResolvablePromise<T> = WrappedPromise<T> & PromiseWithResolvers<T>
 
 export function resolvablePromise<T>(): ResolvablePromise<T> {
-  const promiseWithResolvers = Promise.withResolvers<T>()
+  // const promiseWithResolvers = Promise.withResolvers<T>()
+  // Promise.withResolvers is too recent. Let's use the polyfill instead.
+  let resolve: PromiseWithResolvers<T>['resolve']
+  let reject: PromiseWithResolvers<T>['reject']
+  const promise = new Promise<T>((resolve_, reject_) => {
+    resolve = resolve_
+    reject = reject_
+  })
+  const promiseWithResolvers = { promise, resolve: resolve!, reject: reject! }
+
   return Object.assign(promiseWithResolvers, wrapPromise<T>(promiseWithResolvers.promise))
 }

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -1,45 +1,31 @@
-export type WrappedPromise<T> = Promise<T> & {
+export type WrappedPromise<T> = {
+  promise: Promise<T>
   resolved?: T
-  rejected?: Error
+  rejected?: unknown
 }
-// TODO(SL) maybe improve the type or structure so that the user does not provide a simple promise
-// maybe force adding a "pending: true" key while it's not resolved or rejected?
-// eg: {pending: true} | {resolved: T} | {rejected: Error}
 
-/**
- * Wrap a promise to save the resolved value and error.
- * Note: you can't await on a WrappedPromise, you must use then.
- */
-export function wrapPromise<T>(promise: Promise<T> | T): WrappedPromise<T> {
-  if (!(promise instanceof Promise)) {
-    promise = Promise.resolve(promise)
+export function wrapPromise<T>(promise: Promise<T>): WrappedPromise<T>
+export function wrapPromise<T>(resolved: T): WrappedPromise<T>
+export function wrapPromise<T>(value: Promise<T> | T): WrappedPromise<T> {
+  const wrappedPromise: WrappedPromise<T> = {
+    promise: value instanceof Promise ? value : Promise.resolve(value),
   }
-  const wrapped: WrappedPromise<T> = promise.then(resolved => {
-    wrapped.resolved = resolved
-    return resolved
-  }).catch(rejected => {
-    wrapped.rejected = rejected
-    throw rejected
+  // add resolved or rejected property to the asyncValue
+  wrappedPromise.promise.then(value => {
+    wrappedPromise.resolved = value
+    wrappedPromise.rejected = undefined
+    return value
+  }).catch(error => {
+    wrappedPromise.resolved = undefined
+    wrappedPromise.rejected = error
+    throw error
   })
-  return wrapped
+  return wrappedPromise
 }
 
-export type ResolvablePromise<T> = Promise<T> & {
-  resolve: (value: T) => void
-  reject: (error: Error) => void
-}
+export type ResolvablePromise<T> = WrappedPromise<T> & PromiseWithResolvers<T>
 
-/**
- * Create a promise that can be resolved or rejected later.
- */
 export function resolvablePromise<T>(): ResolvablePromise<T> {
-  let resolve: (value: T) => void
-  let reject: (error: Error) => void
-  const promise = wrapPromise(new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })) as ResolvablePromise<T>
-  promise.resolve = resolve!
-  promise.reject = reject!
-  return promise
+  const promiseWithResolvers = Promise.withResolvers<T>()
+  return Object.assign(promiseWithResolvers, wrapPromise<T>(promiseWithResolvers.promise))
 }

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -6,19 +6,19 @@ export type WrappedPromise<T> = {
 
 export function wrapPromise<T>(promise: Promise<T>): WrappedPromise<T>
 export function wrapPromise<T>(resolved: T): WrappedPromise<T>
-export function wrapPromise<T>(value: Promise<T> | T): WrappedPromise<T> {
+export function wrapPromise<T>(input: Promise<T> | T): WrappedPromise<T> {
   const wrappedPromise: WrappedPromise<T> = {
-    promise: value instanceof Promise ? value : Promise.resolve(value),
+    promise: input instanceof Promise ? input : Promise.resolve(input),
   }
   // add resolved or rejected property to the asyncValue
-  wrappedPromise.promise.then(value => {
-    wrappedPromise.resolved = value
+  wrappedPromise.promise.then(resolved => {
+    wrappedPromise.resolved = resolved
     wrappedPromise.rejected = undefined
-    return value
-  }).catch(error => {
+    return resolved
+  }).catch(rejected => {
     wrappedPromise.resolved = undefined
-    wrappedPromise.rejected = error
-    throw error
+    wrappedPromise.rejected = rejected
+    throw rejected
   })
   return wrappedPromise
 }

--- a/src/row.ts
+++ b/src/row.ts
@@ -22,7 +22,7 @@ export interface Row {
  */
 export interface PartialRow {
   index?: number
-  cells: Partial<Cells> // I added Partial for clarity, even if the result is the same
+  cells: Partial<Cells> // use Partial for clarity, even if the result is the same
 }
 
 /**
@@ -78,9 +78,10 @@ export function resolvableRow(header: string[]): ResolvableRow {
  * @param numRows Number of expected rows when the promise resolves.
  * @param header Column names.
  *
- * @returns Array of AsyncRows.
+ * @returns Array of ResolvableRow (AsyncRow + all the wrapped promises have resolve and reject functions).
+ * A ResolvableRow is also an AsyncRow.
  */
-export function asyncRows(rowsPromise: Promise<Row[]>, numRows: number, header: string[]): AsyncRow[] {
+export function asyncRows(rowsPromise: Promise<Row[]>, numRows: number, header: string[]): ResolvableRow[] {
   // Make grid of resolvable promises
   const resolvableRows = new Array(numRows).fill(null).map(_ => resolvableRow(header))
   rowsPromise.then(rows => {
@@ -103,8 +104,6 @@ export function asyncRows(rowsPromise: Promise<Row[]>, numRows: number, header: 
       resolvableRows[i].index.reject(error)
     }
   })
-  // TODO(SL): should we 'hide' the resolve/reject methods in the returned objects for them to be
-  // 'real' AsyncRow, or is it fine to return ResolvableRow?
   return resolvableRows
 }
 

--- a/src/row.ts
+++ b/src/row.ts
@@ -1,35 +1,67 @@
 import { ResolvablePromise, WrappedPromise, resolvablePromise } from './promise.js'
 
-/**
- * A row where each cell is a promise.
- * The promise must be wrapped with `wrapPromise` so that HighTable can render
- * the state synchronously.
- */
-export interface AsyncRow {
-  cells: Record<string, WrappedPromise<any>>
-  index: WrappedPromise<number>
-}
+// TODO(SL): replace any with unknown everywhere, as it's more typesafe + add typescript check
 
+/**
+ * A dictionary of cells, where the key is the column name and the value is the cell value.
+ */
 export type Cells = Record<string, any>
 
 /**
- * A row where each cell is a resolved value.
+ * A data row.
+ * `index` is the row index.
+ * `cells` is a dictionary of cells
  */
 export interface Row {
-  cells: Cells
   index: number
+  cells: Cells
 }
 
+/**
+ * A partial row, where the index and the cells can be missing.
+ */
 export interface PartialRow {
   index?: number
-  cells: Cells
+  cells: Partial<Cells> // I added Partial for clarity, even if the result is the same
 }
 
+/**
+ * A row where the index and each cell is a promise.
+ * The promise must be wrapped with `wrapPromise` so that HighTable can render
+ * the state synchronously:
+ * - index.promise is the promise for the row index
+ * - index.resolved, if present, is the resolved value of the row index
+ * - index.rejected, if present, is the error of rejected promise for the row index
+ * The same applies to each cell.
+ */
+export interface AsyncRow {
+  index: WrappedPromise<number>
+  cells: Record<string, WrappedPromise<any>>
+}
+
+/**
+ * A row where the index and each cell is a resolvable promise.
+ *
+ * A resolvable row is used as a placeholder for a row that will be filled "manually"
+ * in the future, using the resolve/reject methods on the index and each cell.
+ * The promise will not resolve automatically. It is wrapped (with `wrapPromise`)
+ * so that the resolved value can be accessed synchronously using `.resolved`.
+ *
+ * Use `resolvableRow` to create a new resolvable row, or `resolvablePromise` to
+ * create a new resolvable promise.
+ */
 export interface ResolvableRow {
-  cells: Record<string, ResolvablePromise<any>>
   index: ResolvablePromise<number>
+  cells: Record<string, ResolvablePromise<any>>
 }
 
+/**
+ * Create a new resolvable row.
+ *
+ * @param header the column names.
+ *
+ * @returns A new resolvable row.
+ */
 export function resolvableRow(header: string[]): ResolvableRow {
   return {
     index: resolvablePromise<number>(),
@@ -41,50 +73,66 @@ export function resolvableRow(header: string[]): ResolvableRow {
  * Helper method to wrap future rows into AsyncRows.
  * Helpful when you want to define a DataFrame with simple async fetching of rows.
  * This function turns future data into a "grid" of wrapped promises.
+ *
+ * @param rowsPromise Promise of rows to be fetched.
+ * @param numRows Number of expected rows when the promise resolves.
+ * @param header Column names.
+ *
+ * @returns Array of AsyncRows.
  */
-export function asyncRows(rows: Promise<Row[]>, numRows: number, header: string[]): AsyncRow[] {
+export function asyncRows(rowsPromise: Promise<Row[]>, numRows: number, header: string[]): AsyncRow[] {
   // Make grid of resolvable promises
-  const wrapped = new Array(numRows).fill(null).map(_ => resolvableRow(header))
-  rows.then(rows => {
+  const resolvableRows = new Array(numRows).fill(null).map(_ => resolvableRow(header))
+  rowsPromise.then(rows => {
     if (rows.length !== numRows) {
       console.warn(`Expected ${numRows} rows, got ${rows.length}`)
     }
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i]
       for (const key of header) {
-        wrapped[i].cells[key].resolve(row.cells[key])
+        resolvableRows[i].cells[key].resolve(row.cells[key])
       }
-      wrapped[i].index.resolve(row.index)
+      resolvableRows[i].index.resolve(row.index)
     }
   }).catch(error => {
     // Reject all promises on error
     for (let i = 0; i < numRows; i++) {
       for (const key of header) {
-        wrapped[i].cells[key].reject(error)
+        resolvableRows[i].cells[key].reject(error)
       }
-      wrapped[i].index.reject(error)
+      resolvableRows[i].index.reject(error)
     }
   })
-  return wrapped
+  // TODO(SL): should we 'hide' the resolve/reject methods in the returned objects for them to be
+  // 'real' AsyncRow, or is it fine to return ResolvableRow?
+  return resolvableRows
 }
 
 /**
- * Await all promises in an AsyncRow and return resolved row.
+ * Await all promises (index, cells) in an AsyncRow and return resolved row.
+ *
+ * @param row AsyncRow
+ *
+ * @returns Promise of resolved row.
  */
 export async function awaitRow(row: AsyncRow): Promise<Row> {
-  const indexPromise = row.index
-  const cellPromises = Object.values(row.cells)
+  const indexPromise = row.index.promise
+  const valuePromises = Object.values(row.cells).map(d => d.promise)
   const cellKeys = Object.keys(row.cells)
-  const [resolvedIndex, ...resolvedOtherValues] = await Promise.all([indexPromise, ...cellPromises])
+  const [index, ...values] = await Promise.all([indexPromise, ...valuePromises])
   return {
-    index: resolvedIndex,
-    cells: Object.fromEntries(cellKeys.map((key, i) => [key, resolvedOtherValues[i]])),
+    index,
+    cells: Object.fromEntries(cellKeys.map((key, i) => [key, values[i]])),
   }
 }
 
 /**
-   * Await all promises in list of AsyncRows and return resolved rows.
-   */
+ * Helper method to await async rows (resolve all indexes and cells) and return resolved rows.
+ *
+ * @param rows Array of AsyncRows
+ *
+ * @returns Promise of resolved rows.
+ */
 export function awaitRows(rows: AsyncRow[]): Promise<Row[]> {
   return Promise.all(rows.map(awaitRow))
 }

--- a/test/promise.test.ts
+++ b/test/promise.test.ts
@@ -3,13 +3,13 @@ import { resolvablePromise } from '../src/promise.js'
 
 describe('resolvablePromise', () => {
   it('should resolve with a value', async () => {
-    const promise = resolvablePromise<number>()
-    promise.resolve(42)
+    const { promise, resolve } = resolvablePromise<number>()
+    resolve(42)
     await expect(promise).resolves.toBe(42)
   })
   it('should reject with an error', async () => {
-    const promise = resolvablePromise<number>()
-    promise.reject(new Error('Failed'))
+    const { promise, reject } = resolvablePromise<number>()
+    reject(new Error('Failed'))
     await expect(promise).rejects.toThrow('Failed')
   })
 })

--- a/test/promise.test.ts
+++ b/test/promise.test.ts
@@ -3,13 +3,31 @@ import { resolvablePromise } from '../src/promise.js'
 
 describe('resolvablePromise', () => {
   it('should resolve with a value', async () => {
-    const { promise, resolve } = resolvablePromise<number>()
-    resolve(42)
-    await expect(promise).resolves.toBe(42)
+    const wrapped = resolvablePromise<number>()
+    wrapped.resolve(42)
+
+    // the resolved value is not in the object yet
+    expect(wrapped.resolved).toBe(undefined)
+
+    // await the promise to get the value
+    await expect(wrapped.promise).resolves.toBe(42)
+
+    // the resolved value is stored in the wrapped object
+    expect(wrapped.resolved).toBe(42)
+    expect(wrapped.rejected).toBe(undefined)
   })
   it('should reject with an error', async () => {
-    const { promise, reject } = resolvablePromise<number>()
-    reject(new Error('Failed'))
-    await expect(promise).rejects.toThrow('Failed')
+    const wrapped = resolvablePromise<number>()
+    wrapped.reject(new Error('Failed'))
+
+    // the rejected error is not in the object yet
+    expect(wrapped.rejected).toBe(undefined)
+
+    // await the promise to get the error
+    await expect(wrapped.promise).rejects.toThrow(new Error('Failed'))
+
+    // the rejected error is stored in the wrapped object
+    expect(wrapped.resolved).toBe(undefined)
+    expect(wrapped.rejected).toBeInstanceOf(Error)
   })
 })


### PR DESCRIPTION
While trying to work on the following idea:

https://github.com/hyparam/hightable/blob/7962b4e43a0a23d47329642d127929c20c4fdeac/src/promise.ts#L5

I first propose to follow the `Promise.withResolvers()` standard.

What the PR does:
- use [`Promise.withResolvers()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers) (well a polyfill) for the promise + resolve and reject. The format of `WrappedPromise` is then now `{promise, resolve, reject, resolved, rejected}` instead of adding these fields to the Promise object.
- export `WrappedPromise` type
- add doctrings

Problem: I cannot fix an error in the tests, see https://github.com/hyparam/hightable/pull/38#issuecomment-2648856853.

---

Besides this PR, why I'm worried about the current status is that nothing forces a dataframe implementation to set `resolved` or `rejected`. I think it's easy to forget this part (if the user does not use `wrapPromise`), while it's crucial in the code: we get the data from the `resolved` field, not from the promise.

An alternative might be to pass each Promise to the Cell component and handle a local state there, rendering when the promise has been resolved. It might be simpler to understand and work with, and it's well-supported with [`use`](https://react.dev/reference/react/use#use) and [`Suspense`](https://react.dev/reference/react/Suspense). But possibly other problems could arise. wdyt @platypii?