### PR TITLE
use React 18.2.0 to build the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Breaking** only support `AsyncRow[]` (instead of `AsyncRow[] | Promise<Row[]>`) as the return type of the `rows` function in the `DataFrame` object ([#36](https://github.com/hyparam/hightable/pull/36)).
 - **Breaking** changed the format of rows. Instead of `Record<string, any>` with an optional `__index__` field, rows are now `Row` objects with a mandatory index: `{index: number, cells: Record<string, any>[]}` ([#36](https://github.com/hyparam/hightable/pull/36)).
 
+### Fixed
+
+- build the package with the lowest compatible React version: React 18.2.0. Note that HighTable is compatible with higher versions, like ^19.
+
 ### Refactored
 
 - use `Promise.all` to fail fast when fetching the cells ([#37](https://github.com/hyparam/hightable/pull/37)).

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "eslint-plugin-react": "7.37.4",
     "eslint-plugin-react-hooks": "5.1.0",
     "jsdom": "26.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "tslib": "2.8.1",
     "typescript": "5.7.3",
     "typescript-eslint": "8.19.1",


### PR DESCRIPTION
see https://github.com/hyparam/hightable/blob/master/CHANGELOG.md#092---2025-01-30-deprecated

cc @platypii 