### PR TITLE
Decouple scroll and data fetch

### DIFF
--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -249,7 +249,7 @@ export default function HighTable({
   // fetch rows
   useEffect(() => {
     /**
-     * Compute the rows to fetch based on the current scroll position.
+     * Fetch the rows in the range [start, end) and update the state.
     */
     async function fetchRows() {
       const { start, end } = rowsRange
@@ -313,7 +313,6 @@ export default function HighTable({
     }
     // update
     fetchRows()
-
   }, [data, invalidate, onError, orderBy?.column, rows.length, rowsOrderBy.column, rowsRange, rowsStart])
 
   /**

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -221,7 +221,7 @@ export default function HighTable({
       const scrollTop = scrollRef.current?.scrollTop || 0 // scroll position
 
       // determine rows to fetch based on current scroll position (indexes refer to the virtual table domain)
-      const startView = Math.floor(data.numRows * scrollTop / scrollHeight )
+      const startView = Math.floor(data.numRows * scrollTop / scrollHeight)
       const endView = Math.ceil(data.numRows * (scrollTop + clientHeight) / scrollHeight)
       const start = Math.max(0, startView - overscan)
       const end = Math.min(data.numRows, endView + overscan)


### PR DESCRIPTION
Some refactoring

- decouple the scroll/resize and the rows data fetch
- remove columnWidths from the state (it's unrelated to the rest)