### PR TITLE
export sort index in dataframe

### DIFF
--- a/src/dataframe.ts
+++ b/src/dataframe.ts
@@ -4,20 +4,31 @@ import { AsyncRow, Cells, Row, asyncRows, awaitRows } from './row.js'
 /**
  * Streamable row data
  */
-export interface DataFrame {
+export interface BaseDataFrame {
   header: string[]
   numRows: number
   // Rows are 0-indexed, excludes the header, end is exclusive
+  rows(start: number, end: number): AsyncRow[]
+  sortable?: false
+}
+
+/**
+ * Streamable row data
+ */
+export type SortableDataFrame = Omit<BaseDataFrame, 'sortable' | 'rows'> & {
+  // Rows are 0-indexed, excludes the header, end is exclusive
   // if orderBy is provided, start and end are applied to the sorted rows
   rows(start: number, end: number, orderBy?: string): AsyncRow[]
-  sortable?: boolean
+  sortable: true
 }
+
+export type DataFrame = SortableDataFrame | BaseDataFrame
 
 /**
  * Wraps a DataFrame to make it sortable.
  * Requires fetching all rows to sort.
  */
-export function sortableDataFrame(data: DataFrame): DataFrame {
+export function sortableDataFrame(data: DataFrame): SortableDataFrame {
   if (data.sortable) return data // already sortable
   // Fetch all rows
   let all: Promise<Row[]>


### PR DESCRIPTION
To help implement https://github.com/hyparam/hightable/pull/34, we could equip the dataframes with some helpers. Currently, it's:

```javascript
export interface DataFrame {
  header: string[]
  numRows: number
  // Rows are 0-indexed, excludes the header, end is exclusive
  // if orderBy is provided, start and end are applied to the sorted rows
  rows(start: number, end: number, orderBy?: string): AsyncRow[]
  sortable?: boolean
}
```

## Expose the sort indexes

We could expose the sort indexes
```javascript
getSortIndex?: (orderBy: string) => Promise<number[]>
getReverseSortIndex?: (orderBy: string) => Promise<number[]> // (to do reverse lookup in O(1))
``` 

We could even specify `start` and `end`:
```javascript
getSortIndex?: (start: number, end: number, orderBy: string) => Promise<number[]>
getReverseSortIndex?: (start: number, end: number, orderBy: string) => Promise<number[]>
``` 

## Ask for partial rows

Slightly related, we could ask for partial rows:
```javascript
rows(start: number, end: number, orderBy?: string, columns?: string[]): AsyncRow[]
```

in which case 
```javascript
awaitRows(df.rows(start, end, orderBy, []).map(d => d.index))
```
is an equivalent of
```javascript
await getSortIndex (start, end, orderBy)
```

Note that it cannot provide `getReverseSortIndex` this way though.

## Sort in descending order

We could also let implement sort in a descending order:
```javascript
rows(start: number, end: number, orderBy?: string, direction?: 'asc' | 'desc'): AsyncRow[]
```

or 
```javascript
rows(start: number, end: number, orderBy?: OrderBy): AsyncRow[]
```
with 
https://github.com/hyparam/hightable/blob/9dd0695b9ee947265b5651ac99987fc871202c88/src/TableHeader.tsx#L4-L7

## Switch to a parameters object

Switch the parameters of `rows` to an object, instead of ordered arguments, to make it easier to evolve:

```javascript
rows({start: number, end: number, orderBy?: OrderBy, columns?: string[]}): AsyncRow[]
```
