### PR TITLE
Simplify internal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,23 @@
 ### Added
 
 - expose the `stringify` function as a prop of the `HighTable` component ([ef4a642](https://github.com/hyparam/hightable/commit/ef4a642c0c8dc5478abb675e200e2bab2c274518)).
+- export the new function `getGetColumn()` and let the data frame provide its own `getColumn()` function. `getColumn({column, start, end}): any[]` let fetch the data of an individual column ([#53](https://github.com/hyparam/hightable/pull/53)).
 
 ### Changed
 
 - **Breaking** the `rows` method in a data frame now takes a single object argument with the following properties: `start`, `end` and `orderBy` ([#52](https://github.com/hyparam/hightable/pull/52)).
 - **Breaking** the minimal supported React version is now 18.3.1 ([ef4a642](https://github.com/hyparam/hightable/commit/ef4a642c0c8dc5478abb675e200e2bab2c274518)).
+- **Breaking** for accessibility, the top-left cell of the table is now a `<td>` element instead of a `<th>` element ([#57](https://github.com/hyparam/hightable/pull/57)).
 - changed colors in CSS.
+- for accessibility, increased the font size of the cell numbers and made it proportional to the default user font size ([#57](https://github.com/hyparam/hightable/pull/57)).
 
 ### Refactored
 
 - updated the link to the demo in the README ([ef4a642](https://github.com/hyparam/hightable/commit/ef4a642c0c8dc5478abb675e200e2bab2c274518)).
 - removed call to `act()` in tests where not required ([#54](https://github.com/hyparam/hightable/pull/54)).
 - group three properties in internal state into the new `slice` property ([#55](https://github.com/hyparam/hightable/pull/55)).
+- small code reorganization ([#56](https://github.com/hyparam/hightable/pull/56)).
+- simplify the internal state management ([#58](https://github.com/hyparam/hightable/pull/58)).
 
 ## [0.10.0](https://github.com/hyparam/hightable/compare/v0.9.2...v0.10.0) - 2025-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,8 @@
 
 - updated the link to the demo in the README ([ef4a642](https://github.com/hyparam/hightable/commit/ef4a642c0c8dc5478abb675e200e2bab2c274518)).
 - removed call to `act()` in tests where not required ([#54](https://github.com/hyparam/hightable/pull/54)).
-- group three properties in internal state into the new `slice` property ([#55](https://github.com/hyparam/hightable/pull/55)).
 - small code reorganization ([#56](https://github.com/hyparam/hightable/pull/56)).
-- simplify the internal state management ([#58](https://github.com/hyparam/hightable/pull/58)).
+- simplify the internal state management ([#55](https://github.com/hyparam/hightable/pull/55) and [#58](https://github.com/hyparam/hightable/pull/58)).
 
 ## [0.10.0](https://github.com/hyparam/hightable/compare/v0.9.2...v0.10.0) - 2025-02-11
 

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -107,12 +107,17 @@ export default function HighTable({
    */
 
   // true if at least one row is fully resolved (all of its cells)
-  const hasCompleteRow = useMemo(() => slice ? slice.rows.some(row => {
+  const hasCompleteRow = useMemo(() => {
+    if (!slice) {
+      return false
+    }
     const { header } = slice.data
-    const columns = Object.keys(row.cells)
-    if (header.length !== columns.length) return false
-    return columns.every(column => header.includes(column))
-  }) : false, [slice])
+    return slice.rows.some(row => {
+      const columns = Object.keys(row.cells)
+      if (header.length !== columns.length) return false
+      return columns.every(column => header.includes(column))
+    })
+  }, [slice])
 
   // Sorting is disabled if the data is not sortable
   const {

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -111,11 +111,10 @@ export default function HighTable({
     if (!slice) {
       return false
     }
-    const { header } = slice.data
+    const columnsSet = new Set(slice.data.header)
     return slice.rows.some(row => {
-      const columns = Object.keys(row.cells)
-      if (header.length !== columns.length) return false
-      return columns.every(column => header.includes(column))
+      const keys = Object.keys(row.cells)
+      return keys.length === columnsSet.size && keys.every(key => columnsSet.has(key))
     })
   }, [slice])
 

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -79,6 +79,7 @@ export default function HighTable({
 }: TableProps) {
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
+  const [hasCompleteRow, setHasCompleteRow] = useState(false)
 
   const [columnWidths, setColumnWidths] = useState<Array<number | undefined>>([])
   const setColumnWidth = useCallback((columnIndex: number, columnWidth: number | undefined) => {
@@ -107,16 +108,16 @@ export default function HighTable({
    */
 
   // true if at least one row is fully resolved (all of its cells)
-  const hasCompleteRow = useMemo(() => {
-    if (!slice) {
-      return false
-    }
+  if (!hasCompleteRow && slice && slice.rows.length > 0 && slice.data === data) {
+    // the conditions are met to check if at least one row is complete
     const columnsSet = new Set(slice.data.header)
-    return slice.rows.some(row => {
+    if (slice.rows.some(row => {
       const keys = Object.keys(row.cells)
       return keys.length === columnsSet.size && keys.every(key => columnsSet.has(key))
-    })
-  }, [slice])
+    })) {
+      setHasCompleteRow(true)
+    }
+  }
 
   // Sorting is disabled if the data is not sortable
   const {
@@ -191,6 +192,7 @@ export default function HighTable({
   // invalidate when data changes so that columns will auto-resize
   if (slice && data !== slice.data) {
     setSlice(undefined)
+    setHasCompleteRow(false)
     // if uncontrolled, reset the selection (otherwise, it's the responsibility of the parent to do it if the data changes)
     if (!isSelectionControlled) {
       onSelectionChange?.({ ranges: [], anchor: undefined })

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -107,18 +107,6 @@ export default function HighTable({
    * - data.rows(tableIndex, tableIndex + 1, orderBy)
    */
 
-  // true if at least one row is fully resolved (all of its cells)
-  if (!hasCompleteRow && slice && slice.rows.length > 0 && slice.data === data) {
-    // the conditions are met to check if at least one row is complete
-    const columnsSet = new Set(slice.data.header)
-    if (slice.rows.some(row => {
-      const keys = Object.keys(row.cells)
-      return keys.length === columnsSet.size && keys.every(key => columnsSet.has(key))
-    })) {
-      setHasCompleteRow(true)
-    }
-  }
-
   // Sorting is disabled if the data is not sortable
   const {
     value: orderBy,
@@ -285,6 +273,16 @@ export default function HighTable({
             data,
           }
           setSlice(slice)
+          if (!hasCompleteRow) {
+            // check if at least one row is complete
+            const columnsSet = new Set(slice.data.header)
+            if (slice.rows.some(row => {
+              const keys = Object.keys(row.cells)
+              return keys.length === columnsSet.size && keys.every(key => columnsSet.has(key))
+            })) {
+              setHasCompleteRow(true)
+            }
+          }
         }, 10)
         updateRows() // initial update
 


### PR DESCRIPTION
We don't need a complex state with a reducter. It's simpler with a single state (`Slice | undefined`) and easier to understand, I think.