### PR TITLE
enable sorting in descending order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased](https://github.com/hyparam/hightable/compare/v0.12.1...HEAD)
 
+### Changed
+
+- **Breaking** the `OrderBy` type is now an array of column sorts: `{ column: string; direction: 'ascending' | 'descending' }[]`. If empty, the data is not sorted. If it contains one element, the data is sorted along the column, in the specified direction. If it contains multiple elements, the first column is used to sort, then the second one is used for the rows with the same value, and so on ([#67](https://github.com/hyparam/hightable/pull/67), [#68](https://github.com/hyparam/hightable/pull/68)).
+- **Breaking** the `orderBy` property in `rows` method uses the new `OrderBy` type. If `data.sortable` is `true`, the data frame is able to sort along the columns as described above.
+- **Breaking** the `orderBy` property in `HighTable` and `TableHeader` uses the new `OrderBy` type.
+- **Breaking** the `onOrderByChange` property in `HighTable` and `TableHeader` that takes the new `OrderBy` argument.
+- **Breaking** successive clicks on a column header follow a new behavior: instead of toggling between ascending sort and no sort, it now cycles through ascending, descending, and no sort ([#68](https://github.com/hyparam/hightable/pull/68)).
+
 ## [0.12.1](https://github.com/hyparam/hightable/compare/v0.12.0...v0.12.1) - 2025-03-07
-
-### Refactored
-
-- upgraded dependencies.
 
 ### Refactored
 

--- a/src/HighTable.tsx
+++ b/src/HighTable.tsx
@@ -148,12 +148,12 @@ export default function HighTable({
   }, [onSelectionChange, data.numRows, selection])
   const pendingSelectionRequest = useRef(0)
   const getOnSelectRowClick = useCallback(({ tableIndex, dataIndex }: {tableIndex: number, dataIndex?: number}) => {
-    // computeNewSelection is responsible to resolve the dataIndex if undefined but needed
     if (!selection) return
     async function onSelectRowClick(event: MouseEvent) {
       if (!selection) return
       const useAnchor = event.shiftKey && selection.anchor !== undefined
       const requestId = ++pendingSelectionRequest.current
+      // computeNewSelection is responsible to resolve the dataIndex if undefined but needed
       const newSelection = await computeNewSelection({
         selection,
         tableIndex,

--- a/src/TableHeader.tsx
+++ b/src/TableHeader.tsx
@@ -144,8 +144,7 @@ export default function TableHeader({
   )
 
   const directionByColumn = useMemo(() => {
-    // TODO(SL): support descending order
-    return new Map((orderBy ?? []).map(({ column }) => [column, 'ascending'] as const))
+    return new Map((orderBy ?? []).map(({ column, direction }) => [column, direction]))
   }, [orderBy])
 
   const memoizedStyles = useMemo(() => columnWidths.map(cellStyle), [columnWidths])

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,5 +1,8 @@
+export type Direction = 'ascending' | 'descending'
+
 export interface ColumnOrderBy {
     column: string // column name to sort by.
+    direction: Direction // sort direction.
 }
 
 export type OrderBy = ColumnOrderBy[]
@@ -9,8 +12,7 @@ export function areEqualOrderBy(a: OrderBy, b: OrderBy): boolean {
   return a.every((itemA, i) => {
     const itemB = b[i]
     if (!itemB) return false
-    return itemA.column === itemB.column
-    // TODO(SL): compare direction when descending is supported
+    return itemA.column === itemB.column && itemA.direction === itemB.direction
   })
 }
 
@@ -37,22 +39,18 @@ export function toggleColumn(column: string, orderBy: OrderBy): OrderBy {
     //   return [...orderBy, { column, direction: 'ascending' }]
     // for now: remove the existing columns and only sort by the new column
     // none -> ascending
-    return [{ column }]
+    return [{ column, direction: 'ascending' }]
+  } else if (item.direction === 'ascending') {
+    // TODO(SL): when multiple columns are not supported yet, replace the column with descending
+    //   return [...prefix, { column, direction: 'descending' }, ...suffix]
+    // for now: remove the existing columns and only sort by the new column
+    // ascending -> descending
+    return [{ column, direction: 'descending' }]
+  } else {
+    // TODO(SL): when multiple columns are not supported yet, remove the column
+    //   return [...prefix, ...suffix]
+    // for now: return an empty array
+    // descending -> none
+    return []
   }
-  // else:
-  // ascending -> none
-  return []
-
-  // TODO(SL): when descending is supported, add:
-  //
-  // if (item.direction === 'ascending') {
-  //   // ascending -> descending
-  //   return [...prefix, { column, direction: 'descending' }, ...suffix]
-
-  // and
-  //
-  // } else {
-  //   // descending -> none
-  //   return [...prefix, ...suffix]
-  // }
 }

--- a/test/HighTable.test.tsx
+++ b/test/HighTable.test.tsx
@@ -152,8 +152,29 @@ describe('When sorted, HighTable', () => {
     let rows = within(tbody).getAllByRole('row')
     checkRowContents(rows[0], '1', 'row 0', '1,000')
 
-    // Click on the Count header to sort by Count
+    // Click on the Count header to sort by Count (none -> ascending)
     const countHeader = getByRole('columnheader', { name: 'Count' })
+    await user.click(countHeader)
+    await findAllByRole('cell', { name: 'row 999' })
+
+    rows = within(within(getByRole('grid')).getAllByRole('rowgroup')[1]).getAllByRole('row')
+    checkRowContents(rows[0], '1,000', 'row 999', '1')
+
+    // Click again on the Count header to sort by descending Count (ascending -> descending)
+    await user.click(countHeader)
+    await findAllByRole('cell', { name: 'row 0' })
+
+    rows = within(within(getByRole('grid')).getAllByRole('rowgroup')[1]).getAllByRole('row')
+    checkRowContents(rows[0], '1', 'row 0', '1,000')
+
+    // Click again on the Count header to remove the sort (descending -> none)
+    await user.click(countHeader)
+    await findAllByRole('cell', { name: 'row 0' })
+
+    rows = within(within(getByRole('grid')).getAllByRole('rowgroup')[1]).getAllByRole('row')
+    checkRowContents(rows[0], '1', 'row 0', '1,000')
+
+    // Click on the Count header to sort by Count (none -> ascending)
     await user.click(countHeader)
     await findAllByRole('cell', { name: 'row 999' })
 
@@ -180,6 +201,15 @@ describe('When sorted, HighTable', () => {
     await user.dblClick(cell999)
 
     expect(mockDoubleClick).toHaveBeenCalledWith(expect.anything(), 0, 999)
+
+    // Click on the Count header to sort by descending Count
+    await user.click(countHeader)
+
+    const cell00 = await findByRole('cell', { name: 'row 0' })
+
+    await user.dblClick(cell00)
+
+    expect(mockDoubleClick).toHaveBeenCalledWith(expect.anything(), 0, 0)
   })
 })
 

--- a/test/TableHeader.test.tsx
+++ b/test/TableHeader.test.tsx
@@ -136,7 +136,7 @@ describe('TableHeader', () => {
     })
   })
 
-  it('sets orderBy to the column name when a header is clicked', async () => {
+  it('sets orderBy to the column name (ascending order) when a header is clicked', async () => {
     const { columnWidths, setColumnWidth, setColumnWidths } = mockColumnWidths()
     const onOrderByChange = vi.fn()
     const { user, getByText } = render(<table>
@@ -153,10 +153,10 @@ describe('TableHeader', () => {
     const ageHeader = getByText('Age')
     await user.click(ageHeader)
 
-    expect(onOrderByChange).toHaveBeenCalledWith([{ column: 'Age' }])
+    expect(onOrderByChange).toHaveBeenCalledWith([{ column: 'Age', direction: 'ascending' }])
   })
 
-  it('toggles orderBy to undefined when the same header is clicked again', async () => {
+  it('sets orderBy to the column name (descending order) when a header is clicked if it was already sorted by ascending order', async () => {
     const { columnWidths, setColumnWidth, setColumnWidths } = mockColumnWidths()
     const onOrderByChange = vi.fn()
     const { user, getByText } = render(<table>
@@ -166,7 +166,27 @@ describe('TableHeader', () => {
         setColumnWidth={setColumnWidth}
         setColumnWidths={setColumnWidths}
         onOrderByChange={onOrderByChange}
-        orderBy={[{ column: 'Age' }]}
+        orderBy={[{ column: 'Age', direction: 'ascending' }]}
+        dataReady={dataReady} />
+    </table>)
+
+    const ageHeader = getByText('Age')
+    await user.click(ageHeader)
+
+    expect(onOrderByChange).toHaveBeenCalledWith([{ column: 'Age', direction: 'descending' }])
+  })
+
+  it('sets orderBy to undefined when a header is clicked if it was already sorted by descending order', async () => {
+    const { columnWidths, setColumnWidth, setColumnWidths } = mockColumnWidths()
+    const onOrderByChange = vi.fn()
+    const { user, getByText } = render(<table>
+      <TableHeader
+        header={header}
+        columnWidths={columnWidths}
+        setColumnWidth={setColumnWidth}
+        setColumnWidths={setColumnWidths}
+        onOrderByChange={onOrderByChange}
+        orderBy={[{ column: 'Age', direction: 'descending' }]}
         dataReady={dataReady} />
     </table>)
 
@@ -186,14 +206,14 @@ describe('TableHeader', () => {
         setColumnWidth={setColumnWidth}
         setColumnWidths={setColumnWidths}
         onOrderByChange={onOrderByChange}
-        orderBy={[{ column: 'Age' }]}
+        orderBy={[{ column: 'Age', direction: 'ascending' }]}
         dataReady={dataReady} />
     </table>)
 
     const addressHeader = getByText('Address')
     await user.click(addressHeader)
 
-    expect(onOrderByChange).toHaveBeenCalledWith([{ column: 'Address' }])
+    expect(onOrderByChange).toHaveBeenCalledWith([{ column: 'Address', direction: 'ascending' }])
   })
 
   it('does not change orderBy when clicking on the resize handle', async () => {

--- a/test/dataframe.test.ts
+++ b/test/dataframe.test.ts
@@ -108,8 +108,8 @@ describe('sortableDataFrame', () => {
     ].map((cells, index) => ({ cells, index })))
   })
 
-  it('should return data sorted by column "age"', async () => {
-    const rows = await awaitRows(sortableDf.rows({ start: 0, end: 4, orderBy: [{ column: 'age' }] }))
+  it('should return data sorted by column "age" in ascending order', async () => {
+    const rows = await awaitRows(sortableDf.rows({ start: 0, end: 4, orderBy: [{ column: 'age', direction: 'ascending' as const }] }))
     expect(rows).toEqual([
       { index: 2, cells:{ id: 2, name: 'Bob', age: 20 } },
       { index: 3, cells:{ id: 4, name: 'Dani', age: 20 } },
@@ -118,11 +118,29 @@ describe('sortableDataFrame', () => {
     ])
   })
 
-  it('should slice the sorted data correctly', async () => {
-    const rows = await awaitRows(sortableDf.rows({ start: 1, end: 3, orderBy: [{ column: 'id' }] }))
+  it('should return data sorted by column "age" in descending order', async () => {
+    const rows = await awaitRows(sortableDf.rows({ start: 0, end: 4, orderBy: [{ column: 'age', direction: 'descending' as const }] }))
+    expect(rows).toEqual([
+      { index: 1, cells:{ id: 1, name: 'Alice', age: 30 } },
+      { index: 0, cells:{ id: 3, name: 'Charlie', age: 25 } },
+      { index: 3, cells:{ id: 4, name: 'Dani', age: 20 } },
+      { index: 2, cells:{ id: 2, name: 'Bob', age: 20 } },
+    ])
+  })
+
+  it('should slice the sorted data correctly in ascending order', async () => {
+    const rows = await awaitRows(sortableDf.rows({ start: 1, end: 3, orderBy: [{ column: 'id', direction: 'ascending' as const }] }))
     expect(rows).toEqual([
       { index: 2, cells:{ id: 2, name: 'Bob', age: 20 } },
       { index: 0, cells:{ id: 3, name: 'Charlie', age: 25 } },
+    ])
+  })
+
+  it('should slice the sorted data correctly in descending order', async () => {
+    const rows = await awaitRows(sortableDf.rows({ start: 1, end: 3, orderBy: [{ column: 'id', direction: 'descending' as const }] }))
+    expect(rows).toEqual([
+      { index: 0, cells:{ id: 3, name: 'Charlie', age: 25 } },
+      { index: 2, cells:{ id: 2, name: 'Bob', age: 20 } },
     ])
   })
 
@@ -132,7 +150,7 @@ describe('sortableDataFrame', () => {
   })
 
   it('should throw for invalid orderBy field', () => {
-    expect(() => sortableDf.rows({ start: 0, end: 3, orderBy: [{ column: 'invalid' }] }))
+    expect(() => sortableDf.rows({ start: 0, end: 3, orderBy: [{ column: 'invalid', direction: 'ascending' as const }] }))
       .toThrowError('Invalid orderBy field: invalid')
   })
 })

--- a/test/sort.test.ts
+++ b/test/sort.test.ts
@@ -1,38 +1,49 @@
 import { describe, expect, it } from 'vitest'
 import { areEqualOrderBy, partitionOrderBy, toggleColumn } from '../src/sort'
 
+const nameAsc = { column: 'name', direction: 'ascending' as const }
+const nameDesc = { column: 'name', direction: 'descending' as const }
+const ageAsc = { column: 'age', direction: 'ascending' as const }
+const idAsc = { column: 'id', direction: 'ascending' as const }
+
 describe('areEqualOrderBy', () => {
   it('should return true if the order by arrays are equal', () => {
     expect(areEqualOrderBy([], [])).toBe(true)
-    expect(areEqualOrderBy([{ column: 'name' }], [{ column: 'name' }])).toBe(true)
-    expect(areEqualOrderBy([{ column: 'name' }, { column: 'age' }], [{ column: 'name' }, { column: 'age' }])).toBe(true)
+    expect(areEqualOrderBy([nameAsc], [nameAsc])).toBe(true)
+    expect(areEqualOrderBy([nameAsc, ageAsc], [nameAsc, ageAsc])).toBe(true)
   })
   it('should return false if the order by arrays are not equal', () => {
-    expect(areEqualOrderBy([{ column: 'name' }], [{ column: 'age' }])).toBe(false)
-    expect(areEqualOrderBy([{ column: 'name' }, { column: 'age' }], [{ column: 'name' }])).toBe(false)
-    expect(areEqualOrderBy([{ column: 'name' }, { column: 'age' }], [{ column: 'age' }, { column: 'name' }])).toBe(false)
+    expect(areEqualOrderBy([nameAsc], [ageAsc])).toBe(false)
+    expect(areEqualOrderBy([nameAsc], [nameDesc])).toBe(false)
+    expect(areEqualOrderBy([nameAsc, ageAsc], [nameAsc])).toBe(false)
+    expect(areEqualOrderBy([nameAsc, ageAsc], [ageAsc, nameAsc])).toBe(false)
   })
 })
 
 describe('partitionOrderBy', () => {
   it('should return the prefix, item and suffix of the orderBy array', () => {
     expect(partitionOrderBy([], 'name')).toEqual({ prefix: [], item: undefined, suffix: [] })
-    expect(partitionOrderBy([{ column: 'name' }], 'name')).toEqual({ prefix: [], item: { column: 'name' }, suffix: [] })
-    expect(partitionOrderBy([{ column: 'name' }, { column: 'age' }], 'name')).toEqual({ prefix: [], item: { column: 'name' }, suffix: [{ column: 'age' }] })
-    expect(partitionOrderBy([{ column: 'name' }, { column: 'age' }], 'age')).toEqual({ prefix: [{ column: 'name' }], item: { column: 'age' }, suffix: [] })
-    expect(partitionOrderBy([{ column: 'name' }, { column: 'age' }, { column: 'id' }], 'age')).toEqual({ prefix: [{ column: 'name' }], item: { column: 'age' }, suffix: [{ column: 'id' }] })
-    expect(partitionOrderBy([{ column: 'name' }, { column: 'name' }], 'name')).toEqual({ prefix: [], item: { column: 'name' }, suffix: [{ column: 'name' }] })
+    expect(partitionOrderBy([nameAsc], 'name')).toEqual({ prefix: [], item: nameAsc, suffix: [] })
+    expect(partitionOrderBy([nameAsc, ageAsc], 'name')).toEqual({ prefix: [], item: nameAsc, suffix: [ageAsc] })
+    expect(partitionOrderBy([nameAsc, ageAsc], 'age')).toEqual({ prefix: [nameAsc], item: ageAsc, suffix: [] })
+    expect(partitionOrderBy([nameAsc, ageAsc, idAsc], 'age')).toEqual({ prefix: [nameAsc], item: ageAsc, suffix: [idAsc] })
+    expect(partitionOrderBy([nameAsc, nameAsc], 'name')).toEqual({ prefix: [], item: nameAsc, suffix: [nameAsc] })
+    expect(partitionOrderBy([nameDesc, nameAsc], 'name')).toEqual({ prefix: [], item: nameDesc, suffix: [nameAsc] })
   })
 })
 
 describe('toggleColumn', () => {
   it('should return an array with the column if the column is not in the orderBy', () => {
-    expect(toggleColumn('name', [])).toEqual([{ column: 'name' }])
-    expect(toggleColumn('name', [{ column: 'age' }])).toEqual([{ column: 'name' }])
-    expect(toggleColumn('name', [{ column: 'age' }, { column: 'id' }])).toEqual([{ column: 'name' }])
+    expect(toggleColumn('name', [])).toEqual([nameAsc])
+    expect(toggleColumn('name', [ageAsc])).toEqual([nameAsc])
+    expect(toggleColumn('name', [ageAsc, idAsc])).toEqual([nameAsc])
   })
-  it('should return an empty array if the column is in the orderBy', () => {
-    expect(toggleColumn('name', [{ column: 'name' }])).toEqual([])
-    expect(toggleColumn('name', [{ column: 'age' }, { column: 'name' }])).toEqual([])
+  it('should return an array with the column in descending direction, if the column is in the orderBy with ascending direction', () => {
+    expect(toggleColumn('name', [nameAsc])).toEqual([nameDesc])
+    expect(toggleColumn('name', [ageAsc, nameAsc])).toEqual([nameDesc])
+  })
+  it('should return an empty array if the column is in the orderBy with descending direction', () => {
+    expect(toggleColumn('name', [nameDesc])).toEqual([])
+    expect(toggleColumn('name', [ageAsc, nameDesc])).toEqual([])
   })
 })


### PR DESCRIPTION
The table can now be ordered by a column in descending order. When clicking on a column header, we follow the cycle: none -> ascending -> descending -> none...

See #67 for a previous PR where I changed `orderBy: {column: string}` to `orderBy: {column: string}[]`. In this PR, we change it again to `orderBy: {column: string, direction: 'ascending' | 'descending'}[]`.

Issue: #15

in comparison to https://github.com/hyparam/hightable/issues/15#issuecomment-2672901146, I decided that for now, `orderBy` has to be an array, and it has to contain the two properties: `column` and `direction`. We might want to loosen these types later, but I'm not sure it's a good idea, as it creates more special cases, and is not really needed.

(remaining, in another PR: sort by multiple columns)