### PR TITLE
setup hybrid CSS: CSS modules + copy CSS to the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/hyparam/hightable/compare/v0.12.1...HEAD)
 
+### Added
+
+- add a `className` prop to the `HighTable` component ([#74](https://github.com/hyparam/hightable/pull/74)).
+
 ### Changed
 
 - **Breaking** the `OrderBy` type is now an array of column sorts: `{ column: string; direction: 'ascending' | 'descending' }[]`. If empty, the data is not sorted. If it contains one element, the data is sorted along the column, in the specified direction. If it contains multiple elements, the first column is used to sort, then the second one is used for the rows with the same value, and so on ([#67](https://github.com/hyparam/hightable/pull/67), [#68](https://github.com/hyparam/hightable/pull/68)).
@@ -16,6 +20,7 @@
 
 - Use small components instead of defining all the elements in HighTable and TableHeader ([#70](https://github.com/hyparam/hightable/pull/70)).
 - Structure the code files in directories: components/, hooks/, utils/ and helpers/ ([#70](https://github.com/hyparam/hightable/pull/70)).
+- Specify CSS both as a global CSS file and as a CSS module ([#74](https://github.com/hyparam/hightable/pull/74)).
 
 ## [0.12.1](https://github.com/hyparam/hightable/compare/v0.12.0...v0.12.1) - 2025-03-07
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build:bundle": "vite build",
-    "build:css": "cp src/HighTable.css dist/HighTable.css",
+    "build:css": "cat src/HighTable.css >> dist/HighTable.css",
     "build:types": "tsc -b",
     "build": "npm run build:bundle && npm run build:types && npm run build:css",
     "coverage": "vitest run --coverage --coverage.include=src",

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -1,0 +1,2 @@
+.hightable {
+}

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -13,6 +13,7 @@ import RowHeader from '../RowHeader/RowHeader.js'
 import TableCorner from '../TableCorner/TableCorner.js'
 import TableHeader from '../TableHeader/TableHeader.js'
 import { formatRowNumber, rowError } from './HighTable.helpers.js'
+import classes from './HighTable.module.css'
 
 /**
  * A slice of the (optionally sorted) rows to render as HTML.
@@ -351,7 +352,7 @@ export default function HighTable({
 
   const ariaColCount = data.header.length + 1 // don't forget the selection column
   const ariaRowCount = data.numRows + 1 // don't forget the header row
-  return <div className={`table-container${showSelectionControls ? ' selectable' : ''}`}>
+  return <div className={`${classes.hightable} table-container${showSelectionControls ? ' selectable' : ''}`}>
     <div className='table-scroll' ref={scrollRef}>
       <div style={{ height: `${scrollHeight}px` }}>
         <table

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -41,6 +41,7 @@ interface Props {
   selection?: Selection // selection and anchor rows, expressed as data indexes (not as indexes in the table). If undefined, the selection is hidden and the interactions are disabled.
   onSelectionChange?: (selection: Selection) => void // callback to call when a user interaction changes the selection. The selection is expressed as data indexes (not as indexes in the table). The interactions are disabled if undefined.
   stringify?: (value: unknown) => string | undefined
+  className?: string // additional class names
 }
 
 /**
@@ -65,6 +66,7 @@ export default function HighTable({
   onMouseDownCell,
   onError = console.error,
   stringify = stringifyDefault,
+  className = '',
 }: Props) {
   /**
    * The component relies on the model of a virtual table which rows are ordered and only the
@@ -352,7 +354,7 @@ export default function HighTable({
 
   const ariaColCount = data.header.length + 1 // don't forget the selection column
   const ariaRowCount = data.numRows + 1 // don't forget the header row
-  return <div className={`${classes.hightable} table-container${showSelectionControls ? ' selectable' : ''}`}>
+  return <div className={`${classes.hightable} ${className} table-container${showSelectionControls ? ' selectable' : ''}`}>
     <div className='table-scroll' ref={scrollRef}>
       <div style={{ height: `${scrollHeight}px` }}>
         <table

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Super slim PR that allows specifying styles in a CSS module file while keeping global styles:
- styles can be put inside `.hightable {}` in HighTable.module.css, to ensure they are scoped to the component
- the component `HighTable` accepts a new prop `className` aimed at overriding the styles

The PR does not change any behavior or styling.

Follow-up PRs will try to reduce the number of global CSS classes, moving to attribute selectors. See #17.