### PR TITLE
use the same code in hyperparam-cli and hightable to stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased](https://github.com/hyparam/hightable/compare/v0.13.0...HEAD)
 
+### Changed
+
+- Export the default function to stringify cell values as `stringify`, and align the code with the same function in `hyperparam`. The only change is that arrays are now indented ([#82](https://github.com/hyparam/hightable/pull/82)).
+
+### Fixed
+
+- Fix the CSS stacking order to prevent cell placeholders to float above the row headers ([#81](https://github.com/hyparam/hightable/pull/81)).
+
+### Refactored
+
+- Use the variable name `styles` instead of `classes` for CSS module classes ([#83](https://github.com/hyparam/hightable/pull/83)).
+
 ## [0.13.0](https://github.com/hyparam/hightable/compare/v0.12.1...v0.13.0) - 2025-03-21
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,6 @@ export type { Selection } from './helpers/selection.js'
 export type { OrderBy } from './helpers/sort.js'
 export { resolvablePromise, wrapPromise } from './utils/promise.js'
 export type { ResolvablePromise } from './utils/promise.js'
+export { stringify } from './utils/stringify.js'
 export { HighTable }
 export default HighTable

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -1,17 +1,27 @@
-
 /**
  * Robust stringification of any value, including json and bigints.
  */
-export function stringify(value: unknown): string | undefined {
+export function stringify(value: unknown): string {
   if (typeof value === 'string') return value
-  if (typeof value === 'number') return value.toLocaleString()
-  if (typeof value === 'bigint') return value.toLocaleString()
-  if (Array.isArray(value)) return `[${value.map(stringify).join(', ')}]`
+  if (typeof value === 'number' || typeof value === 'bigint') return value.toLocaleString('en-US')
+  if (typeof value === 'boolean') return value.toString()
+  if (Array.isArray(value)) {
+    return `[\n${value.map((v) => indent(stringify(v), 2)).join(',\n')}\n]`
+  }
   if (value === null || value === undefined) return JSON.stringify(value)
   if (value instanceof Date) return value.toISOString()
   if (typeof value === 'object') {
-    return `{${Object.entries(value).map(([k, v]) => `${k}: ${stringify(v)}`).join(', ')}}`
+    return `{${Object.entries(value)
+      .filter((d) => d[1] !== undefined)
+      .map(([k, v]) => `${k}: ${stringify(v)}`)
+      .join(', ')}}`
   }
-  // fallback
-  return JSON.stringify(value)
+  return '{}'
+}
+
+function indent(text: string | undefined, spaces: number) {
+  return text
+    ?.split('\n')
+    .map((line) => ' '.repeat(spaces) + line)
+    .join('\n')
 }

--- a/test/utils/stringify.test.ts
+++ b/test/utils/stringify.test.ts
@@ -21,8 +21,15 @@ describe('stringify', () => {
   })
 
   test('handles arrays', () => {
-    expect(stringify([1, 2, 3])).toBe('[1, 2, 3]')
-    expect(stringify(['a', 'b'])).toBe('[a, b]')
+    expect(stringify([1, 2, 3])).toBe(`[
+  1,
+  2,
+  3
+]`)
+    expect(stringify(['a', 'b'])).toBe(`[
+  a,
+  b
+]`)
   })
 
   test('handles objects', () => {
@@ -35,7 +42,11 @@ describe('stringify', () => {
       a: [1, 2, { x: 'x' }],
       b: { c: 'hello' },
     }
-    expect(stringify(nested)).toBe('{a: [1, 2, {x: x}], b: {c: hello}}')
+    expect(stringify(nested)).toBe(`{a: [
+  1,
+  2,
+  {x: x}
+], b: {c: hello}}`)
   })
 
   test('handles booleans', () => {


### PR DESCRIPTION
Use the same code for stringify in hyperparam and hightable + export stringify (I removed it accidentally in a previous PR).

Note: it's a bit inconsistent to indent the arrays but not the objects. Do we want this behavior anyway @platypii?

```js
test('handles nested objects and arrays', () => {
    const nested = {
      a: [1, 2, { x: 'x' }],
      b: { c: 'hello' },
    }
    expect(stringify(nested)).toBe(`{a: [
  1,
  2,
  {x: x}
], b: {c: hello}}`)
  })
```