### PR TITLE
Use column width in the table cells, not only in the column headers

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,11 +1,12 @@
-import { CSSProperties, MouseEvent, useMemo } from 'react'
+import { MouseEvent, useMemo } from 'react'
+import useColumnWidth from '../../hooks/useColumnWidth.js'
 
 interface Props {
   onDoubleClick?: (event: MouseEvent) => void
   onMouseDown?: (event: MouseEvent) => void
   stringify: (value: unknown) => string | undefined
-  style?: CSSProperties
   value: any
+  columnIndex: number
 }
 
 /**
@@ -13,11 +14,15 @@ interface Props {
  *
  * @param props
  * @param props.value cell value
- * @param props.style CSS properties
+ * @param props.columnIndex column index in the dataframe (0-based)
  * @param props.onDoubleClick double click callback
  * @param props.onMouseDown mouse down callback
  */
-export default function Cell({ onDoubleClick, onMouseDown, stringify, style, value }: Props) {
+export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value }: Props) {
+  // Get the column width from the context
+  const { getColumnStyle } = useColumnWidth()
+  const columnStyle = getColumnStyle?.(columnIndex)
+
   // render as truncated text
   const str = useMemo(() => {
     return stringify(value)
@@ -39,7 +44,7 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, style, val
       aria-busy={str === undefined}
       onDoubleClick={onDoubleClick}
       onMouseDown={onMouseDown}
-      style={style}
+      style={columnStyle}
       title={title}>
       {str}
     </td>

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -1,29 +1,30 @@
-import { MouseEvent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { MouseEvent, ReactNode, useCallback, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { Direction } from '../../helpers/sort.js'
-import { cellStyle, measureWidth } from '../../helpers/width.js'
-import { useLocalStorageState } from '../../hooks/useLocalStorageState.js'
+import { measureWidth } from '../../helpers/width.js'
+import useColumnWidth from '../../hooks/useColumnWidth.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
 
 interface Props {
+  columnIndex: number // index of the column in the dataframe (0-based)
   children?: ReactNode
   dataReady?: boolean
   direction?: Direction
-  localStorageKey?: string
   onClick?: (e: MouseEvent) => void
   title?: string
   sortable?: boolean
 }
 
-export default function ColumnHeader({ children, dataReady, direction, localStorageKey, onClick, title, sortable }: Props) {
+export default function ColumnHeader({ columnIndex, dataReady, direction, onClick, title, sortable, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const [width, setWidth] = useLocalStorageState<number>({ key: localStorageKey ? `${localStorageKey}:width` : undefined })
-  const [resizeWidth, setResizeWidth] = useState<number | undefined>(undefined)
-  const currentWidth = resizeWidth ?? width
 
-  const style = useMemo(() => {
-    return cellStyle(currentWidth)
-  }, [currentWidth])
+  // Get the column width from the context
+  const { getColumnStyle, setColumnWidth, getColumnWidth } = useColumnWidth()
+  const columnStyle = getColumnStyle?.(columnIndex)
+  const width = getColumnWidth?.(columnIndex)
+  const setWidth = useCallback((nextWidth: number | undefined) => {
+    setColumnWidth?.({ columnIndex, width: nextWidth })
+  }, [setColumnWidth, columnIndex])
 
   // Measure default column width when data is ready
   useEffect(() => {
@@ -45,6 +46,10 @@ export default function ColumnHeader({ children, dataReady, direction, localStor
         setWidth(undefined)
       })
       const nextWidth = measureWidth(element)
+      // TODO(SL): take the ColumnResizer size into account, because if
+      // the column title is larger than the cell values, the title is
+      // truncated
+      // TODO(SL): add a threshold to avoid resizing too small columns
       if (!isNaN(nextWidth)) {
         // should not happen in the browser (but fails in unit tests)
         setWidth(nextWidth)
@@ -60,13 +65,12 @@ export default function ColumnHeader({ children, dataReady, direction, localStor
       aria-sort={direction ?? 'none'}
       aria-disabled={!sortable}
       onClick={onClick}
-      style={style}
+      style={columnStyle}
       title={title}
     >
       {children}
       <ColumnResizer
-        setFinalWidth={setWidth}
-        setResizeWidth={setResizeWidth}
+        setWidth={setWidth}
         onDoubleClick={autoResize}
         width={width}
       />

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -2,12 +2,11 @@ import { MouseEvent, useCallback, useEffect, useState } from 'react'
 
 interface Props {
   onDoubleClick?: () => void
-  setResizeWidth?: (width?: number) => void
-  setFinalWidth?: (width: number) => void
+  setWidth?: (width: number | undefined) => void
   width?: number
 }
 
-export default function ColumnResizer({ onDoubleClick, setFinalWidth, setResizeWidth, width }: Props) {
+export default function ColumnResizer({ onDoubleClick, setWidth, width }: Props) {
   const [resizeClientX, setResizeClientX] = useState<number | undefined>(undefined)
 
   // Disable click event propagation
@@ -20,15 +19,15 @@ export default function ColumnResizer({ onDoubleClick, setFinalWidth, setResizeW
     e.stopPropagation()
     const nextResizeWidth = width ?? 0
     setResizeClientX(e.clientX - nextResizeWidth)
-    setResizeWidth?.(nextResizeWidth)
-  }, [setResizeWidth, width])
+    setWidth?.(nextResizeWidth)
+  }, [setWidth, width])
 
   // Handle mouse move event during resizing
   useEffect(() => {
     if (resizeClientX !== undefined) {
       function updateResizeWidth(clientX: number) {
         return function(event: globalThis.MouseEvent) {
-          setResizeWidth?.(Math.max(1, event.clientX - clientX))
+          setWidth?.(Math.max(1, event.clientX - clientX))
         }
       }
       const listener = updateResizeWidth(resizeClientX)
@@ -37,15 +36,14 @@ export default function ColumnResizer({ onDoubleClick, setFinalWidth, setResizeW
         window.removeEventListener('mousemove', listener)
       }
     }
-  }, [resizeClientX, setResizeWidth])
+  }, [resizeClientX, setWidth])
 
   // Handle mouse up to end resizing
   useEffect(() => {
     if (resizeClientX !== undefined) {
       function stopResizing(clientX: number) {
         return function(event: globalThis.MouseEvent) {
-          setFinalWidth?.(Math.max(1, event.clientX - clientX))
-          setResizeWidth?.(undefined)
+          setWidth?.(Math.max(1, event.clientX - clientX))
           setResizeClientX(undefined)
         }
       }
@@ -55,7 +53,7 @@ export default function ColumnResizer({ onDoubleClick, setFinalWidth, setResizeW
         window.removeEventListener('mouseup', listener)
       }
     }
-  }, [resizeClientX, setFinalWidth, setResizeWidth])
+  }, [resizeClientX, setWidth])
 
   return (
     <span

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -4,7 +4,6 @@ import ColumnHeader from '../ColumnHeader/ColumnHeader.js'
 
 interface TableProps {
   header: string[]
-  cacheKey?: string // used to persist column widths
   orderBy?: OrderBy // array of column order by clauses. If undefined, the table is unordered, the sort elements are hidden and the interactions are disabled.
   onOrderByChange?: (orderBy: OrderBy) => void // callback to call when a user interaction changes the order. The interactions are disabled if undefined.
   dataReady: boolean
@@ -15,7 +14,7 @@ interface TableProps {
  * Render a header for a table.
  */
 export default function TableHeader({
-  header, cacheKey, orderBy, onOrderByChange, dataReady, sortable = true,
+  header, orderBy, onOrderByChange, dataReady, sortable = true,
 }: TableProps) {
   // Function to handle click for changing orderBy
   const getOnOrderByClick = useCallback((columnHeader: string) => {
@@ -29,26 +28,20 @@ export default function TableHeader({
     return new Map((orderBy ?? []).map(({ column, direction }) => [column, direction]))
   }, [orderBy])
 
-  return header.map((name, index) => {
-    const suffix = `${index}:${name}`
-    // Considerations:
-    // - File contents can change, so column sizes are saved by name.
-    // - There could be duplicate column names.
-    const localStorageKey = cacheKey ? `${cacheKey}:${suffix}` : undefined
-    // TODO(SL): if we implement changing the order of the columns, or hiding columns,
-    // we might want to replace `index` with something else in the key
-    // to preserve the element between refreshes
-    const key = localStorageKey ?? suffix
+  return header.map((name, columnIndex) => {
+    // Note: columnIndex is the index of the column in the dataframe header
+    // and not the index of the column in the table (which can be different if
+    // some columns are hidden, or if the order is changed)
     return (
       // The ColumnHeader component width is controlled by the parent
       <ColumnHeader
-        key={key}
-        localStorageKey={localStorageKey}
+        key={columnIndex}
         dataReady={dataReady}
         direction={directionByColumn.get(name)}
         onClick={getOnOrderByClick(name)}
         sortable={sortable}
         title={name}
+        columnIndex={columnIndex}
       >
         {name}
       </ColumnHeader>

--- a/src/hooks/useColumnWidth.tsx
+++ b/src/hooks/useColumnWidth.tsx
@@ -1,0 +1,87 @@
+import { CSSProperties, ReactNode, createContext, useCallback, useContext, useMemo } from 'react'
+import { cellStyle } from '../helpers/width.js'
+import { useLocalStorageState } from '../hooks/useLocalStorageState.js'
+
+interface WidthSetterOptions {
+  columnIndex: number;
+  width?: number; // undefined to remove the width
+}
+
+interface ColumnWidthContextType {
+  getColumnWidth?: (columnIndex: number) => number | undefined
+  getColumnStyle?: (columnIndex: number) => CSSProperties
+  setColumnWidth?: (options: WidthSetterOptions) => void
+}
+
+export const ColumnWidthContext = createContext<ColumnWidthContextType>({})
+
+interface ColumnWidthProviderProps {
+  localStorageKey?: string // optional key to use for local storage (no local storage if not provided)
+  children: ReactNode
+}
+
+// in local storage, uninitialized values are stored as null, not as undefined
+type StoredWidths = (number | undefined | null)[]
+
+export function ColumnWidthProvider({ children, localStorageKey }: ColumnWidthProviderProps) {
+  // An array of column widths
+  // The index is the column rank in the header (0-based)
+  // The array is uninitialized so that we don't have to know the number of columns in advance
+  const [widths, setWidths] = useLocalStorageState<StoredWidths>({ key: localStorageKey })
+
+  const getColumnWidth = useCallback((columnIndex: number) => {
+    const width = widths?.[columnIndex]
+    if (width === undefined || width === null) {
+      return undefined
+    }
+    if (isNaN(width) || width < 0) {
+      // TODO(SL): add a warning if the width seems too big?
+      console.warn(`Invalid column width for column index ${columnIndex}: ${width}. Ignoring it.`)
+      return undefined
+    }
+    return width
+  }, [widths])
+
+  const getColumnStyle = useCallback((columnIndex: number) => {
+    return cellStyle(getColumnWidth(columnIndex))
+  }, [getColumnWidth])
+
+  const setColumnWidth = useCallback(({ columnIndex, width }: WidthSetterOptions) => {
+    setWidths(widths => {
+      if (width !== undefined && (isNaN(width) || width < 0)) {
+        // TODO(SL): add a warning if the width seems too big?
+        throw new Error(`Invalid column width: ${width}`)
+      }
+      if (widths?.[columnIndex] === width) {
+        // no change (avoid useless re-renders)
+        return widths
+      }
+      const next = [...widths ?? []]
+      if (width === undefined) {
+        next[columnIndex] = undefined
+      } else {
+        // Note: if columnIndex is an invalid array index, it will be ignored
+        next[columnIndex] = width
+      }
+      return next
+    })
+  }, [setWidths])
+
+  const value = useMemo(() => {
+    return {
+      getColumnWidth,
+      getColumnStyle,
+      setColumnWidth,
+    }
+  }, [getColumnWidth, getColumnStyle, setColumnWidth])
+
+  return (
+    <ColumnWidthContext.Provider value={value}>
+      {children}
+    </ColumnWidthContext.Provider>
+  )
+}
+
+export default function useColumnWidth() {
+  return useContext(ColumnWidthContext)
+}

--- a/src/hooks/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState.ts
@@ -1,4 +1,4 @@
-import { Dispatch, useCallback, useState } from 'react'
+import { Dispatch, SetStateAction, useCallback, useState } from 'react'
 
 /**
  * Get value from local storage for a key.
@@ -13,7 +13,10 @@ function loadFromLocalStorage(key: string): unknown {
  *
  * If value is undefined, the column value is removed from local storage.
  */
-function saveToOrDeleteFromLocalStorage(key: string, value: unknown) {
+function saveToOrDeleteFromLocalStorage({ key, value }: { key?: string, value: unknown }) {
+  if (key === undefined) {
+    return
+  }
   if (value === undefined) {
     localStorage.removeItem(key)
   } else {
@@ -32,18 +35,16 @@ function saveToOrDeleteFromLocalStorage(key: string, value: unknown) {
  * Note that the values stored with a previous key are maintained.
  * TODO(SL): add a way to delete them?
  *
- * Contrarily to useState, the initial value is always undefined, and the setter argument cannot be a function.
+ * Contrarily to useState, the initial value is always undefined.
  *
- * @param [string | undefined] key The key to use in local storage. If undefined, the value is not persisted.
+ * @param options
+ * @param [string | undefined] options.key The key to use in local storage. If undefined, the value is not persisted.
  *
- * @returns [T | undefined, Dispatch<T | undefined>] The value and the setter.
+ * @returns [T | undefined, Dispatch<SetStateAction<T | undefined>>] The value and the setter.
  */
-export function useLocalStorageState<T>({ key }: {key?: string} = {}): [T | undefined, Dispatch<T | undefined>] {
-  const [value, setValue] = useState<T | undefined>(() => {
-    // TODO(SL): check if the type of loaded value is T | undefined, accepting a check function as an argument?
-    return key === undefined ? undefined : loadFromLocalStorage(key) as T | undefined
-  })
-  const [lastCacheKey, setLastCacheKey] = useState<string | undefined>(key)
+export function useLocalStorageState<T>({ key }: { key?: string } = {}): [T | undefined, Dispatch<SetStateAction<T | undefined>>] {
+  const [value, setValue] = useState<T | undefined>(undefined)
+  const [lastCacheKey, setLastCacheKey] = useState<string | undefined>(undefined)
   if (key !== lastCacheKey) {
     if (key !== undefined) {
       // TODO(SL): check if the type of loaded value is T | undefined, accepting a check function as an argument?
@@ -51,10 +52,24 @@ export function useLocalStorageState<T>({ key }: {key?: string} = {}): [T | unde
     } // else: do not change the value
     setLastCacheKey(key)
   }
-  const memoizedSetValue = useCallback((nextValue: T | undefined) => {
-    setValue(nextValue)
-    if (key !== undefined) {
-      saveToOrDeleteFromLocalStorage(key, nextValue)
+
+  const memoizedSetValue = useCallback((valueOrSetter: SetStateAction<T | undefined>) => {
+    if (typeof valueOrSetter === 'function') {
+      // Typescript does not provide a way to prevent T from being a function,
+      // so we have to assume that the function is a setter, and cast it.
+      const setter = valueOrSetter as (prevState: T | undefined) => T | undefined
+      if (key === undefined) {
+        setValue(setter)
+      } else {
+        const currentValue = loadFromLocalStorage(key) as T | undefined
+        const nextValue = setter(currentValue)
+        setValue(nextValue)
+        saveToOrDeleteFromLocalStorage({ key, value: nextValue })
+      }
+    } else {
+      const nextValue = valueOrSetter
+      setValue(nextValue)
+      saveToOrDeleteFromLocalStorage({ key, value: nextValue })
     }
   }, [key])
 

--- a/test/hooks/useLocalStorageState.test.ts
+++ b/test/hooks/useLocalStorageState.test.ts
@@ -115,4 +115,29 @@ describe('useLocalStorageState hook', () => {
     })
     expect(localStorage.length).toEqual(0)
   })
+
+  it('supports a function as a setter', () => {
+    const { result } = renderHook(() => useLocalStorageState<number | undefined>({ key: 'key' }))
+    const [ , setValue ] = result.current
+    act(() => {
+      setValue((prev) => (prev ?? 0) + 1)
+    })
+    const [ value ] = result.current
+    expect(value).toEqual(1)
+    expect(localStorage.getItem('key')).toEqual('1')
+    expect(localStorage.length).toEqual(1)
+    act(() => {
+      setValue((prev) => (prev ?? 0) + 1)
+    })
+    const [ value2 ] = result.current
+    expect(value2).toEqual(2)
+    expect(localStorage.getItem('key')).toEqual('2')
+    expect(localStorage.length).toEqual(1)
+    act(() => {
+      setValue(() => { return undefined })
+    })
+    const [ value3 ] = result.current
+    expect(value3).toEqual(undefined)
+    expect(localStorage.length).toEqual(0)
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/hyparam/hightable/issues/91

The column widths state is lifted up to the HighTable component.

We removed the subtletly of not saving to local storage during the resizing for simplicity (saving a small array to local storage is neglictable in comparison to re-render, I guess).