### PR TITLE
highlight the primary sort column

### DIFF
--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -13,9 +13,11 @@ interface Props {
   onClick?: (e: MouseEvent) => void
   title?: string
   sortable?: boolean
+  ariaPosInSet?: number // index of the column in the orderBy array (0-based)
+  ariaSetSize?: number // size of the orderBy array
 }
 
-export default function ColumnHeader({ columnIndex, dataReady, direction, onClick, title, sortable, children }: Props) {
+export default function ColumnHeader({ columnIndex, dataReady, direction, onClick, title, sortable, ariaPosInSet, ariaSetSize, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
 
   // Get the column width from the context
@@ -64,6 +66,8 @@ export default function ColumnHeader({ columnIndex, dataReady, direction, onClic
       role="columnheader"
       aria-sort={direction ?? 'none'}
       aria-disabled={!sortable}
+      aria-posinset={ariaSetSize !== undefined ? ariaPosInSet : undefined}
+      aria-setsize={ariaSetSize}
       onClick={onClick}
       style={columnStyle}
       title={title}

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -193,7 +193,12 @@
     right: 8px;
     top: 8px;
     padding-left: 2px;
-    background-color: #f1f1f3;
+    background: none;
+    color: #d5d4d6;
+  }
+
+  th[aria-posinset="0"]::after {
+    color: inherit;
   }
 
   tbody tr:first-child {

--- a/src/components/HighTable/HighTable.stories.tsx
+++ b/src/components/HighTable/HighTable.stories.tsx
@@ -1,17 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { sortableDataFrame, wrapPromise } from 'hightable'
+import { useState } from 'react'
 import { DataFrame } from '../../helpers/dataframe.js'
+import { OrderBy } from '../../helpers/sort.js'
 import { wrapResolved } from '../../utils/promise.js'
 import HighTable from './HighTable.js'
 
+function random(seed: number) {
+  const x = Math.sin(seed) * 10000
+  return x - Math.floor(x)
+}
+
 const data: DataFrame = {
-  header: ['ID', 'Count'],
+  header: ['ID', 'Count', 'Value1', 'Value2', 'Value3'],
   numRows: 1000,
   rows: ({ start, end }) => Array.from({ length: end - start }, (_, index) => ({
     index: wrapResolved(index + start),
     cells: {
       ID: wrapResolved(`row ${index + start}`),
       Count: wrapResolved(1000 - start - index),
+      Value1: wrapResolved(Math.floor(100 * random(135 + index))),
+      Value2: wrapResolved(Math.floor(100 * random(648 + index))),
+      Value3: wrapResolved(Math.floor(100 * random(315 + index))),
     },
   })),
 }
@@ -37,6 +47,8 @@ const delayedData = sortableDataFrame({
   }),
 })
 
+const sortableData = sortableDataFrame(data)
+
 const meta: Meta<typeof HighTable> = {
   component: HighTable,
 }
@@ -51,5 +63,25 @@ export const Default: Story = {
 export const Placeholders: Story = {
   args: {
     data: delayedData,
+  },
+}
+
+export const MultiSort: Story = {
+  render: (args) => {
+    const [orderBy, setOrderBy] = useState<OrderBy>([
+      { column: 'Count', direction: 'ascending' },
+      { column: 'Value1', direction: 'descending' },
+      { column: 'Value2', direction: 'ascending' },
+    ])
+    return (
+      <HighTable
+        {...args}
+        orderBy={orderBy}
+        onOrderByChange={setOrderBy}
+      />
+    )
+  },
+  args: {
+    data: sortableData,
   },
 }

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -24,8 +24,8 @@ export default function TableHeader({
     }}, [orderBy, onOrderByChange]
   )
 
-  const directionByColumn = useMemo(() => {
-    return new Map((orderBy ?? []).map(({ column, direction }) => [column, direction]))
+  const orderByColumn = useMemo(() => {
+    return new Map((orderBy ?? []).map(({ column, direction }, index) => [column, { direction, index }]))
   }, [orderBy])
 
   return header.map((name, columnIndex) => {
@@ -37,7 +37,9 @@ export default function TableHeader({
       <ColumnHeader
         key={columnIndex}
         dataReady={dataReady}
-        direction={directionByColumn.get(name)}
+        direction={orderByColumn.get(name)?.direction}
+        ariaPosInSet={orderByColumn.get(name)?.index}
+        ariaSetSize={orderBy?.length}
         onClick={getOnOrderByClick(name)}
         sortable={sortable}
         title={name}


### PR DESCRIPTION
fixes #93

Use the `aria-posinset` attribute to style the column header depending on its sort order

```css
  th[aria-posinset="0"]::after {
    color: inherit;
  }
```


https://github.com/user-attachments/assets/f88b2327-6ba1-4868-948f-97d42eb148ba

