### PR TITLE
don't save to localstorage if cacheKey is not provided

### DIFF
--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -29,17 +29,17 @@ export default function ColumnHeader({ columnIndex, dataReady, direction, onClic
     setColumnWidth?.({ columnIndex, width: nextWidth })
   }, [setColumnWidth, columnIndex])
 
-  // Measure default column width when data is ready
+  // Measure default column width when data is ready, if no width is set
   useEffect(() => {
     const element = ref.current
-    if (dataReady && element) {
+    if (dataReady && element && width === undefined) {
       const nextWidth = measureWidth(element)
       if (!isNaN(nextWidth)) {
         // should not happen in the browser (but fails in unit tests)
         setWidth(nextWidth)
       }
     }
-  }, [dataReady, setWidth])
+  }, [dataReady, setWidth, width])
 
   const autoResize = useCallback(() => {
     const element = ref.current

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -374,7 +374,7 @@ export default function HighTable({
 
   const ariaColCount = data.header.length + 1 // don't forget the selection column
   const ariaRowCount = data.numRows + 1 // don't forget the header row
-  return <ColumnWidthProvider localStorageKey={`${cacheKey}:column-widths`}>
+  return <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
     <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
       <div className={styles.tableScroll} ref={scrollRef}>
         <div style={{ height: `${scrollHeight}px` }}>

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -30,7 +30,7 @@ const rowHeight = 33 // row height px
 
 interface Props {
   data: DataFrame
-  cacheKey?: string // used to persist column widths
+  cacheKey?: string // used to persist column widths. If undefined, the column widths are not persisted. It is expected to be unique for each table.
   overscan?: number // number of rows to fetch outside of the viewport
   padding?: number // number of padding rows to render outside of the viewport
   focus?: boolean // focus table on mount? (default true)


### PR DESCRIPTION
It previously saved to "undefined:column-widths" 🤦

Also, I fixed a more subtle bug: the column were always autoresized when the data was changed. Now, it uses the local storage if it is already set. I updated the docs.