### PR TITLE
Fix autosize

### DIFF
--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -49,10 +49,6 @@ export default function ColumnHeader({ columnIndex, dataReady, direction, onClic
         setWidth(undefined)
       })
       const nextWidth = measureWidth(element)
-      // TODO(SL): take the ColumnResizer size into account, because if
-      // the column title is larger than the cell values, the title is
-      // truncated
-      // TODO(SL): add a threshold to avoid resizing too small columns
       if (!isNaN(nextWidth)) {
         // should not happen in the browser (but fails in unit tests)
         setWidth(nextWidth)

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -65,7 +65,7 @@ export default function ColumnHeader({ columnIndex, dataReady, direction, onClic
       ref={ref}
       scope="col"
       role="columnheader"
-      aria-sort={direction ?? 'none'}
+      aria-sort={direction ?? (sortable ? 'none' : undefined)}
       aria-disabled={!sortable}
       aria-posinset={ariaSetSize !== undefined ? ariaPosInSet : undefined}
       aria-setsize={ariaSetSize}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -66,7 +66,6 @@ export default function ColumnHeader({ columnIndex, dataReady, direction, onClic
       scope="col"
       role="columnheader"
       aria-sort={direction ?? (sortable ? 'none' : undefined)}
-      aria-disabled={!sortable}
       aria-posinset={ariaSetSize !== undefined ? ariaPosInSet : undefined}
       aria-setsize={ariaSetSize}
       onClick={onClick}

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -44,7 +44,7 @@
   }
 
   /* sortable */
-  thead th[aria-disabled="false"] {
+  thead th[aria-sort] {
     cursor: pointer;
   }
   th[aria-sort="ascending"]::after,
@@ -188,14 +188,13 @@
       top: -1px; /* fix 1px gap above thead */
 
       /* sorting is enabled - add space for the sort caret */
-      &[aria-disabled="false"] {
+      &[aria-sort] {
         padding-right: calc(var(--cell-horizontal-padding) + 8px);
       }
     }
   }
 
-  th[aria-sort="ascending"]::after,
-  th[aria-sort="descending"]::after {
+  th[aria-sort]::after {
     right: 8px;
     top: 8px;
     padding-left: 2px;

--- a/src/helpers/width.ts
+++ b/src/helpers/width.ts
@@ -12,5 +12,6 @@ export function measureWidth(element: HTMLTableCellElement): number {
   // get computed cell padding
   const style = window.getComputedStyle(element)
   const horizontalPadding = parseInt(style.paddingLeft) + parseInt(style.paddingRight)
-  return element.offsetWidth - horizontalPadding
+  // add 1px to avoid rounding errors, since offsetWidth always returns an integer
+  return element.offsetWidth - horizontalPadding + 1
 }


### PR DESCRIPTION
Add 1px to avoid rounding errors when using [offsetWidth](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth). An alternative is to use [getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect), but maybe it's good enough this way and less resource-consuming (even if it's a micro-optimization).

![Screenshot From 2025-04-16 17-20-32](https://github.com/user-attachments/assets/77102e4d-87d1-4963-b07a-db8d102fae49)

Also (a bit unrelated to the PR matter): remove `aria-disabled` (potentially breaking, even if it had been added recently) and always use `aria-sort` to style, as it's clearer semantically.

Before:

![Screenshot From 2025-04-16 17-25-23](https://github.com/user-attachments/assets/fe588106-3d5e-467d-a8f3-ea85b076d65b)

After:

![Screenshot From 2025-04-16 17-25-09](https://github.com/user-attachments/assets/f38d3bbf-3771-4c4b-b604-7927b8107e81)
