### PR TITLE
get row index as soon as possible when unsorted

### DIFF
--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -416,8 +416,9 @@ export default function HighTable({
               })}
               {slice?.rows.map((row, rowIndex) => {
                 const tableIndex = slice.offset + rowIndex
-                const dataIndex = row.index
-                const selected = isRowSelected(row.index) ?? false
+                const inferredDataIndex = orderBy === undefined || orderBy.length === 0 ? tableIndex : undefined
+                const dataIndex = row.index ?? inferredDataIndex
+                const selected = isRowSelected(dataIndex) ?? false
                 return (
                   <Row
                     key={tableIndex}


### PR DESCRIPTION
fixes #127

See also https://github.com/hyparam/hyperparam-cli/pull/223/files#diff-d106aedf518c583b89a0b89ba35cfc8bb748cf469bdc957898edac0c5f2696d0, that fixed the same issue in hyperparam-cli