### PR TITLE
fix the sort icons + focus the table + improve title/description of columns

### DIFF
--- a/src/components/ColumnHeader/ColumnHeader.test.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.test.tsx
@@ -31,25 +31,25 @@ describe('ColumnHeader', () => {
 
   it('renders column header correctly', () => {
     const content = 'test'
-    const { getByRole } = render(<table><thead><tr><ColumnHeader columnIndex={0}>{content}</ColumnHeader></tr></thead></table>)
+    const { getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0}>{content}</ColumnHeader></tr></thead></table>)
     const element = getByRole('columnheader')
     expect(element.textContent).toEqual(content)
     expect(measureWidth).not.toHaveBeenCalled()
   })
 
   it('measures the width if dataReady is true', () => {
-    render(<table><thead><tr><ColumnHeader columnIndex={0} dataReady={true} /></tr></thead></table>)
+    render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={true} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalled()
   })
 
   it('measures the width again if dataReady toggles to true', () => {
-    const { rerender } = render(<table><thead><tr><ColumnHeader columnIndex={0} dataReady={true} /></tr></thead></table>)
+    const { rerender } = render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={true} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalledTimes(1)
     // new data is being loaded
-    rerender(<table><thead><tr><ColumnHeader columnIndex={0} dataReady={false} /></tr></thead></table>)
+    rerender(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={false} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalledTimes(1)
     // new data is ready
-    rerender(<table><thead><tr><ColumnHeader columnIndex={0} dataReady={true} /></tr></thead></table>)
+    rerender(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={true} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalledTimes(2)
   })
 
@@ -58,7 +58,7 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
 
     const { getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnIndex={0}/></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0}/></tr></thead></table>
     </ColumnWidthProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
@@ -70,7 +70,7 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
 
     const { user, getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
     </ColumnWidthProvider>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('separator')
@@ -89,7 +89,7 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
 
     const { user, getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
     </ColumnWidthProvider>)
 
     // Simulate resizing the column
@@ -118,19 +118,19 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey2, JSON.stringify([width2]))
 
     const { rerender, getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
     </ColumnWidthProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(`${width1}px`)
     rerender(<ColumnWidthProvider localStorageKey={cacheKey2}>
-      <table><thead><tr><ColumnHeader columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
     </ColumnWidthProvider>)
     expect(header.style.maxWidth).toEqual(`${width2}px`)
   })
 
   it('call onClick (eg. to change orderBy) when clicking on the header, but not when clicking on the resize handle', async () => {
     const onClick = vi.fn()
-    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnIndex={0} onClick={onClick} /></tr></thead></table>)
+    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} onClick={onClick} /></tr></thead></table>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('separator')
     await user.click(resizeHandle)

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode, useCallback, useEffect, useRef } from 'react'
+import { MouseEvent, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { Direction } from '../../helpers/sort.js'
 import { measureWidth } from '../../helpers/width.js'
@@ -16,20 +16,6 @@ interface Props {
   ariaPosInSet?: number // index of the column in the orderBy array (0-based)
   ariaSetSize?: number // size of the orderBy array
   className?: string // optional class name
-}
-
-function getActionFromOrderByColumn({ columnName, direction, ariaPosInSet }: { columnName: string; direction?: Direction, ariaPosInSet?: number }) {
-  let prefix = 'Press to '
-  if (ariaPosInSet !== undefined && ariaPosInSet > 0) {
-    prefix += `sort by ${columnName} in ascending order`
-  } else if (direction === 'ascending') {
-    prefix += `sort by ${columnName} in descending order`
-  } else if (direction === 'descending') {
-    prefix += `stop sorting by ${columnName}`
-  } else {
-    prefix += `sort by ${columnName} in ascending order`
-  }
-  return prefix
 }
 
 export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, ariaPosInSet, ariaSetSize, className, children }: Props) {
@@ -70,7 +56,19 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
     }
   }, [setWidth])
 
-  const description = sortable ? getActionFromOrderByColumn({ columnName, direction, ariaPosInSet }) : `The column ${columnName} cannot be sorted`
+  const description = useMemo(() => {
+    if (!sortable) {
+      return `The column ${columnName} cannot be sorted`
+    } else if (ariaPosInSet !== undefined && ariaPosInSet > 0) {
+      return `Press to sort by ${columnName} in ascending order`
+    } else if (direction === 'ascending') {
+      return `Press to sort by ${columnName} in descending order`
+    } else if (direction === 'descending') {
+      return `Press to stop sorting by ${columnName}`
+    } else {
+      return `Press to sort by ${columnName} in ascending order`
+    }
+  }, [sortable, columnName, direction, ariaPosInSet])
 
   return (
     <th

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -7,18 +7,32 @@ import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
 
 interface Props {
   columnIndex: number // index of the column in the dataframe (0-based)
+  columnName: string
   children?: ReactNode
   dataReady?: boolean
   direction?: Direction
   onClick?: (e: MouseEvent) => void
-  title?: string
   sortable?: boolean
   ariaPosInSet?: number // index of the column in the orderBy array (0-based)
   ariaSetSize?: number // size of the orderBy array
   className?: string // optional class name
 }
 
-export default function ColumnHeader({ columnIndex, dataReady, direction, onClick, title, sortable, ariaPosInSet, ariaSetSize, className, children }: Props) {
+function getActionFromOrderByColumn({ columnName, direction, ariaPosInSet }: { columnName: string; direction?: Direction, ariaPosInSet?: number }) {
+  let prefix = 'Press to '
+  if (ariaPosInSet !== undefined && ariaPosInSet > 0) {
+    prefix += `sort by ${columnName} in ascending order`
+  } else if (direction === 'ascending') {
+    prefix += `sort by ${columnName} in descending order`
+  } else if (direction === 'descending') {
+    prefix += `stop sorting by ${columnName}`
+  } else {
+    prefix += `sort by ${columnName} in ascending order`
+  }
+  return prefix
+}
+
+export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, ariaPosInSet, ariaSetSize, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
 
   // Get the column width from the context
@@ -56,17 +70,20 @@ export default function ColumnHeader({ columnIndex, dataReady, direction, onClic
     }
   }, [setWidth])
 
+  const description = sortable ? getActionFromOrderByColumn({ columnName, direction, ariaPosInSet }) : `The column ${columnName} cannot be sorted`
+
   return (
     <th
       ref={ref}
       scope="col"
       role="columnheader"
       aria-sort={direction ?? (sortable ? 'none' : undefined)}
+      aria-description={description}
+      title={description}
       aria-posinset={ariaSetSize !== undefined ? ariaPosInSet : undefined}
       aria-setsize={ariaSetSize}
       onClick={onClick}
       style={columnStyle}
-      title={title}
       className={className}
     >
       {children}

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -54,10 +54,10 @@
     top: 0;
   }
   th[aria-sort="ascending"]::after {
-    content: "▾";
+    content: "▴";
   }
   th[aria-sort="descending"]::after {
-    content: "▴";
+    content: "▾";
   }
 
   /* column resize */

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -164,6 +164,22 @@
   --cell-placeholder-z-index: 1;
   --cell-horizontal-padding: 12px;
 
+  --focus-border-color: black;
+  --focus-border-width: 2px;
+
+  .table-scroll:focus {
+    outline: none;
+    border-radius: 4px;
+    border-color: var(--focus-border-color);
+    border-width: var(--focus-border-width);
+    border-style: solid;
+    & + .mock-row-label {
+      top: var(--focus-border-width);
+      left: var(--focus-border-width);
+      bottom: var(--focus-border-width);
+    }
+  }
+
   table {
     border-collapse: separate;
     border-spacing: 0;

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -376,7 +376,7 @@ export default function HighTable({
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
     <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
-      <div className={styles.tableScroll} ref={scrollRef} tabIndex={0} role="group" aria-labelledby="caption">
+      <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption">
         <div style={{ height: `${scrollHeight}px` }}>
           <table
             aria-readonly={true}

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -376,7 +376,7 @@ export default function HighTable({
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
     <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
-      <div className={styles.tableScroll} ref={scrollRef}>
+      <div className={styles.tableScroll} ref={scrollRef} tabIndex={0}>
         <div style={{ height: `${scrollHeight}px` }}>
           <table
             aria-readonly={true}
@@ -386,7 +386,7 @@ export default function HighTable({
             ref={tableRef}
             role='grid'
             style={{ top: `${offsetTop}px` }}
-            tabIndex={0}>
+          >
             <thead role="rowgroup">
               <Row ariaRowIndex={1} >
                 <TableCorner

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -376,7 +376,7 @@ export default function HighTable({
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
     <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
-      <div className={styles.tableScroll} ref={scrollRef} tabIndex={0}>
+      <div className={styles.tableScroll} ref={scrollRef} tabIndex={0} role="group" aria-labelledby="caption">
         <div style={{ height: `${scrollHeight}px` }}>
           <table
             aria-readonly={true}
@@ -387,6 +387,7 @@ export default function HighTable({
             role='grid'
             style={{ top: `${offsetTop}px` }}
           >
+            <caption id="caption" hidden>Virtual-scroll table</caption>
             <thead role="rowgroup">
               <Row ariaRowIndex={1} >
                 <TableCorner

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -43,7 +43,7 @@ export default function TableHeader({
         ariaSetSize={orderBy?.length}
         onClick={getOnOrderByClick(name)}
         sortable={sortable}
-        title={name}
+        columnName={name}
         columnIndex={columnIndex}
         className={columnClassNames[columnIndex]}
       >


### PR DESCRIPTION
Some preliminary improvements before #30

- fix the sort arrows (they were reversed!!!)
- now, only the scrollable div can be focused. It is outlined with a black outline (in all browsers). Note that it's not explicit with `tabindex`, but the default element focused by the browsers I tested (firefox and chromium) when entering the webpage with `Tab`
- add description + update the title of the column headers, to describe the action when clicking them


https://github.com/user-attachments/assets/b8c39ff2-3777-40f4-8d8f-46035c08834c

