### PR TITLE
increase contrast for row numbers to pass 4.5 contrast ratio

### DIFF
--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -246,7 +246,7 @@
   tbody [role="rowheader"] {
     background-color: #f1f1f3;
     border-right: 1px solid #ddd;
-    color: #888;
+    color: #6d6d6d;
     font-size: 0.68rem;
     padding: 0 2px;
     text-align: center;


### PR DESCRIPTION
4.5 is the minimum contrast (WCAG 2.0 level AA)

Before
![Screenshot From 2025-04-28 12-05-18](https://github.com/user-attachments/assets/25be52f0-2874-47e0-9804-0af6df244d0f)


After
![Screenshot From 2025-04-28 12-05-08](https://github.com/user-attachments/assets/56583478-7a4f-4d76-9983-a90d69f6d317)
