### PR TITLE
Use data attributes, and add aria-colindex

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -47,6 +47,7 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, columnInde
     <td
       role="cell"
       aria-busy={!hasResolved}
+      aria-readonly={true}
       onDoubleClick={onDoubleClick}
       onMouseDown={onMouseDown}
       style={columnStyle}

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -9,6 +9,7 @@ interface Props {
   columnIndex: number
   hasResolved: boolean
   className?: string
+  ariaColIndex?: number
 }
 
 /**
@@ -22,8 +23,9 @@ interface Props {
  * @param props.stringify function to stringify the value
  * @param props.hasResolved function to get the column style
  * @param props.className optional class name
+ * @param props.ariaColIndex optional aria col index
  */
-export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className }: Props) {
+export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex }: Props) {
   // Get the column width from the context
   const { getColumnStyle } = useColumnWidth()
   const columnStyle = getColumnStyle?.(columnIndex)
@@ -48,6 +50,7 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, columnInde
       role="cell"
       aria-busy={!hasResolved}
       aria-readonly={true}
+      aria-colindex={ariaColIndex}
       onDoubleClick={onDoubleClick}
       onMouseDown={onMouseDown}
       style={columnStyle}

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -49,7 +49,6 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, columnInde
     <td
       role="cell"
       aria-busy={!hasResolved}
-      aria-readonly={true}
       aria-colindex={ariaColIndex}
       onDoubleClick={onDoubleClick}
       onMouseDown={onMouseDown}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -13,12 +13,12 @@ interface Props {
   direction?: Direction
   onClick?: (e: MouseEvent) => void
   sortable?: boolean
-  ariaPosInSet?: number // index of the column in the orderBy array (0-based)
-  ariaSetSize?: number // size of the orderBy array
+  orderByIndex?: number // index of the column in the orderBy array (0-based)
+  orderBySize?: number // size of the orderBy array
   className?: string // optional class name
 }
 
-export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, ariaPosInSet, ariaSetSize, className, children }: Props) {
+export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
 
   // Get the column width from the context
@@ -59,7 +59,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
   const description = useMemo(() => {
     if (!sortable) {
       return `The column ${columnName} cannot be sorted`
-    } else if (ariaPosInSet !== undefined && ariaPosInSet > 0) {
+    } else if (orderByIndex !== undefined && orderByIndex > 0) {
       return `Press to sort by ${columnName} in ascending order`
     } else if (direction === 'ascending') {
       return `Press to sort by ${columnName} in descending order`
@@ -68,7 +68,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
     } else {
       return `Press to sort by ${columnName} in ascending order`
     }
-  }, [sortable, columnName, direction, ariaPosInSet])
+  }, [sortable, columnName, direction, orderByIndex])
 
   return (
     <th
@@ -76,11 +76,11 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       scope="col"
       role="columnheader"
       aria-sort={direction ?? (sortable ? 'none' : undefined)}
+      data-order-by-index={orderBySize !== undefined ? orderByIndex : undefined}
+      data-order-by-size={orderBySize}
       aria-description={description}
       aria-readonly={true}
       title={description}
-      aria-posinset={ariaSetSize !== undefined ? ariaPosInSet : undefined}
-      aria-setsize={ariaSetSize}
       onClick={onClick}
       style={columnStyle}
       className={className}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -79,7 +79,6 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       data-order-by-index={orderBySize !== undefined ? orderByIndex : undefined}
       data-order-by-size={orderBySize}
       aria-description={description}
-      aria-readonly={true}
       aria-colindex={columnIndex + 2} // 1-based index, +1 for the row header
       title={description}
       onClick={onClick}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -80,6 +80,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       data-order-by-size={orderBySize}
       aria-description={description}
       aria-readonly={true}
+      aria-colindex={columnIndex + 2} // 1-based index, +1 for the row header
       title={description}
       onClick={onClick}
       style={columnStyle}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -77,6 +77,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       role="columnheader"
       aria-sort={direction ?? (sortable ? 'none' : undefined)}
       aria-description={description}
+      aria-readonly={true}
       title={description}
       aria-posinset={ariaSetSize !== undefined ? ariaPosInSet : undefined}
       aria-setsize={ariaSetSize}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -79,7 +79,9 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       data-order-by-index={orderBySize !== undefined ? orderByIndex : undefined}
       data-order-by-size={orderBySize}
       aria-description={description}
-      aria-colindex={columnIndex + 2} // 1-based index, +1 for the row header
+      // 1-based index, +1 for the row header
+      // TODO(SL): don't hardcode it, but get it from the table context
+      aria-colindex={columnIndex + 2}
       title={description}
       onClick={onClick}
       style={columnStyle}

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -218,7 +218,7 @@
     color: #d5d4d6;
   }
 
-  th[aria-posinset="0"]::after {
+  th[data-order-by-index="0"]::after {
     color: inherit;
   }
 

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -395,6 +395,7 @@ export default function HighTable({
                   checked={allRowsSelected}
                   showCheckBox={showCornerSelection}
                   style={cornerStyle}
+                  ariaColIndex={1}
                 >&nbsp;</TableCorner>
                 <TableHeader
                   dataReady={hasCompleteRow}
@@ -411,7 +412,7 @@ export default function HighTable({
                 const tableIndex = offset - prePadding.length + prePaddingIndex
                 return (
                   <Row key={tableIndex} ariaRowIndex={tableIndex + 2} >
-                    <RowHeader style={cornerStyle} />
+                    <RowHeader style={cornerStyle} ariaColIndex={1} />
                   </Row>
                 )
               })}
@@ -433,6 +434,7 @@ export default function HighTable({
                       onClick={dataIndex === undefined ? undefined : getOnSelectRowClick({ tableIndex, dataIndex })}
                       checked={selected}
                       showCheckBox={showSelection}
+                      ariaColIndex={1}
                     >{formatRowNumber(dataIndex)}</RowHeader>
                     {data.header.map((column, columnIndex) => {
                       // Note: the resolved cell value can be undefined
@@ -447,6 +449,7 @@ export default function HighTable({
                         columnIndex={columnIndex}
                         hasResolved={hasResolved}
                         className={columnClassNames[columnIndex]}
+                        ariaColIndex={columnIndex + 2} // 1-based index, +1 for the row header
                       />
                     })}
                   </Row>
@@ -456,7 +459,7 @@ export default function HighTable({
                 const tableIndex = offset + rowsLength + postPaddingIndex
                 return (
                   <Row key={tableIndex} ariaRowIndex={tableIndex + 2}>
-                    <RowHeader style={cornerStyle} />
+                    <RowHeader style={cornerStyle} ariaColIndex={1} />
                   </Row>
                 )
               })}

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -12,7 +12,14 @@ interface Props {
 export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy }: Props) {
   const disabled = !onClick
   return (
-    <th scope="row" role="rowheader" style={style} onClick={onClick} aria-busy={busy}>
+    <th
+      scope="row"
+      role="rowheader"
+      style={style}
+      onClick={onClick}
+      aria-busy={busy}
+      aria-readonly={true}
+    >
       <span>{children}</span>
       { showCheckBox && <input type='checkbox' disabled={disabled} checked={checked} readOnly /> }
     </th>

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -19,7 +19,6 @@ export default function RowHeader({ children, checked, onClick, showCheckBox, st
       style={style}
       onClick={onClick}
       aria-busy={busy}
-      aria-readonly={true}
       aria-colindex={ariaColIndex}
     >
       <span>{children}</span>

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -7,9 +7,10 @@ interface Props {
   onClick?: (event: MouseEvent) => void
   showCheckBox?: boolean
   style?: CSSProperties
+  ariaColIndex?: number
 }
 
-export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy }: Props) {
+export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex }: Props) {
   const disabled = !onClick
   return (
     <th
@@ -19,6 +20,7 @@ export default function RowHeader({ children, checked, onClick, showCheckBox, st
       onClick={onClick}
       aria-busy={busy}
       aria-readonly={true}
+      aria-colindex={ariaColIndex}
     >
       <span>{children}</span>
       { showCheckBox && <input type='checkbox' disabled={disabled} checked={checked} readOnly /> }

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -6,11 +6,12 @@ interface Props {
   onClick?: (event: MouseEvent) => void
   showCheckBox?: boolean
   style?: CSSProperties
+  ariaColIndex?: number
 }
 
-export default function TableCorner({ children, checked, onClick, showCheckBox, style }: Props) {
+export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex }: Props) {
   return (
-    <td aria-disabled={!showCheckBox} style={style} onClick={onClick}>
+    <td aria-disabled={!showCheckBox} style={style} onClick={onClick} aria-colindex={ariaColIndex}>
       <span>{children}</span>
       { showCheckBox && <input type='checkbox' checked={checked} readOnly /> }
     </td>

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -39,8 +39,8 @@ export default function TableHeader({
         key={columnIndex}
         dataReady={dataReady}
         direction={orderByColumn.get(name)?.direction}
-        ariaPosInSet={orderByColumn.get(name)?.index}
-        ariaSetSize={orderBy?.length}
+        orderByIndex={orderByColumn.get(name)?.index}
+        orderBySize={orderBy?.length}
         onClick={getOnOrderByClick(name)}
         sortable={sortable}
         columnName={name}


### PR DESCRIPTION
Fixes:
- use custom `data-` attributes instead of hacking `aria-` attributes: Instead of `aria-posinset` and `aria-setsize`, use
`data-order-by-index` and `data-order-by-size` to avoid misleading the users. ARIA does not currently support multicolumn sort, so don't try to be clever. See https://github.com/w3c/aria/issues/283
- set `aria-colindex` to the cells. It's explicit and will be useful when implementing column hiding (#3)
