### PR TITLE
Navigate the table with keyboard

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,5 +1,6 @@
-import { MouseEvent, useMemo } from 'react'
+import { MouseEvent, useMemo, useRef } from 'react'
 import useColumnWidth from '../../hooks/useColumnWidth.js'
+import { useTabIndex } from '../../hooks/useFocus.js'
 
 interface Props {
   onDoubleClick?: (event: MouseEvent) => void
@@ -9,7 +10,7 @@ interface Props {
   columnIndex: number
   hasResolved: boolean
   ariaColIndex: number
-  tabIndex: number
+  ariaRowIndex: number
   className?: string
 }
 
@@ -24,10 +25,13 @@ interface Props {
  * @param props.stringify function to stringify the value
  * @param props.hasResolved function to get the column style
  * @param props.ariaColIndex aria col index
- * @param props.tabIndex tab index for the cell
+ * @param props.ariaRowIndex aria row index
  * @param props.className optional class name
  */
-export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex, tabIndex }: Props) {
+export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex, ariaRowIndex }: Props) {
+  const ref = useRef<HTMLTableCellElement>(null)
+  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+
   // Get the column width from the context
   const { getColumnStyle } = useColumnWidth()
   const columnStyle = getColumnStyle?.(columnIndex)
@@ -49,6 +53,7 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, columnInde
   }, [str])
   return (
     <td
+      ref={ref}
       role="cell"
       aria-busy={!hasResolved}
       aria-colindex={ariaColIndex}

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent, useCallback, useMemo, useRef } from 'react'
+import { useCellNavigation } from '../../hooks/useCellsNavigation.js'
 import useColumnWidth from '../../hooks/useColumnWidth.js'
-import { useCellFocus } from '../../hooks/useFocus.js'
 
 interface Props {
   onDoubleClick?: (event: MouseEvent) => void
@@ -30,15 +30,15 @@ interface Props {
  */
 export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex, ariaRowIndex }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const handleMouseDown = useCallback((event: MouseEvent) => {
-    focusCell()
+    navigateToCell()
     onMouseDown?.(event)
-  }, [onMouseDown, focusCell])
+  }, [onMouseDown, navigateToCell])
   const handleDoubleClick = useCallback((event: MouseEvent) => {
-    focusCell()
+    navigateToCell()
     onDoubleClick?.(event)
-  }, [onDoubleClick, focusCell])
+  }, [onDoubleClick, navigateToCell])
 
   // Get the column width from the context
   const { getColumnStyle } = useColumnWidth()

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,6 +1,6 @@
-import { MouseEvent, useMemo, useRef } from 'react'
+import { MouseEvent, useCallback, useMemo, useRef } from 'react'
 import useColumnWidth from '../../hooks/useColumnWidth.js'
-import { useTabIndex } from '../../hooks/useFocus.js'
+import { useCellFocus } from '../../hooks/useFocus.js'
 
 interface Props {
   onDoubleClick?: (event: MouseEvent) => void
@@ -30,7 +30,15 @@ interface Props {
  */
 export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex, ariaRowIndex }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const handleMouseDown = useCallback((event: MouseEvent) => {
+    focusCell()
+    onMouseDown?.(event)
+  }, [onMouseDown, focusCell])
+  const handleDoubleClick = useCallback((event: MouseEvent) => {
+    focusCell()
+    onDoubleClick?.(event)
+  }, [onDoubleClick, focusCell])
 
   // Get the column width from the context
   const { getColumnStyle } = useColumnWidth()
@@ -58,8 +66,8 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, columnInde
       aria-busy={!hasResolved}
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}
-      onDoubleClick={onDoubleClick}
-      onMouseDown={onMouseDown}
+      onDoubleClick={handleDoubleClick}
+      onMouseDown={handleMouseDown}
       style={columnStyle}
       className={className}
       title={title}>

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -8,8 +8,9 @@ interface Props {
   value: any
   columnIndex: number
   hasResolved: boolean
+  ariaColIndex: number
+  tabIndex: number
   className?: string
-  ariaColIndex?: number
 }
 
 /**
@@ -22,10 +23,11 @@ interface Props {
  * @param props.onMouseDown mouse down callback
  * @param props.stringify function to stringify the value
  * @param props.hasResolved function to get the column style
+ * @param props.ariaColIndex aria col index
+ * @param props.tabIndex tab index for the cell
  * @param props.className optional class name
- * @param props.ariaColIndex optional aria col index
  */
-export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex }: Props) {
+export default function Cell({ onDoubleClick, onMouseDown, stringify, columnIndex, value, hasResolved, className, ariaColIndex, tabIndex }: Props) {
   // Get the column width from the context
   const { getColumnStyle } = useColumnWidth()
   const columnStyle = getColumnStyle?.(columnIndex)
@@ -50,6 +52,7 @@ export default function Cell({ onDoubleClick, onMouseDown, stringify, columnInde
       role="cell"
       aria-busy={!hasResolved}
       aria-colindex={ariaColIndex}
+      tabIndex={tabIndex}
       onDoubleClick={onDoubleClick}
       onMouseDown={onMouseDown}
       style={columnStyle}

--- a/src/components/ColumnHeader/ColumnHeader.test.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.test.tsx
@@ -22,6 +22,12 @@ beforeEach(() => {
   localStorage.clear()
 })
 
+const defaultProps = {
+  columnIndex: 0,
+  ariaColIndex: 1,
+  ariaRowIndex: 1,
+}
+
 describe('ColumnHeader', () => {
   const cacheKey = 'key'
 
@@ -31,25 +37,25 @@ describe('ColumnHeader', () => {
 
   it('renders column header correctly', () => {
     const content = 'test'
-    const { getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0}>{content}</ColumnHeader></tr></thead></table>)
+    const { getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps}>{content}</ColumnHeader></tr></thead></table>)
     const element = getByRole('columnheader')
     expect(element.textContent).toEqual(content)
     expect(measureWidth).not.toHaveBeenCalled()
   })
 
   it('measures the width if dataReady is true', () => {
-    render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={true} /></tr></thead></table>)
+    render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} dataReady={true} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalled()
   })
 
   it('measures the width again if dataReady toggles to true', () => {
-    const { rerender } = render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={true} /></tr></thead></table>)
+    const { rerender } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} dataReady={true} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalledTimes(1)
     // new data is being loaded
-    rerender(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={false} /></tr></thead></table>)
+    rerender(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} dataReady={false} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalledTimes(1)
     // new data is ready
-    rerender(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} dataReady={true} /></tr></thead></table>)
+    rerender(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} dataReady={true} /></tr></thead></table>)
     expect(measureWidth).toHaveBeenCalledTimes(2)
   })
 
@@ -58,7 +64,7 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
 
     const { getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0}/></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" {...defaultProps}/></tr></thead></table>
     </ColumnWidthProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
@@ -70,7 +76,7 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
 
     const { user, getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
     </ColumnWidthProvider>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('separator')
@@ -89,7 +95,7 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
 
     const { user, getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
     </ColumnWidthProvider>)
 
     // Simulate resizing the column
@@ -118,19 +124,19 @@ describe('ColumnHeader', () => {
     localStorage.setItem(cacheKey2, JSON.stringify([width2]))
 
     const { rerender, getByRole } = render(<ColumnWidthProvider localStorageKey={cacheKey}>
-      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
     </ColumnWidthProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(`${width1}px`)
     rerender(<ColumnWidthProvider localStorageKey={cacheKey2}>
-      <table><thead><tr><ColumnHeader columnName="test" columnIndex={0} /></tr></thead></table>
+      <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
     </ColumnWidthProvider>)
     expect(header.style.maxWidth).toEqual(`${width2}px`)
   })
 
   it('call onClick (eg. to change orderBy) when clicking on the header, but not when clicking on the resize handle', async () => {
     const onClick = vi.fn()
-    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" columnIndex={0} onClick={onClick} /></tr></thead></table>)
+    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} onClick={onClick} /></tr></thead></table>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('separator')
     await user.click(resizeHandle)

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -3,6 +3,7 @@ import { flushSync } from 'react-dom'
 import { Direction } from '../../helpers/sort.js'
 import { measureWidth } from '../../helpers/width.js'
 import useColumnWidth from '../../hooks/useColumnWidth.js'
+import { useTabIndex } from '../../hooks/useFocus.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
 
 interface Props {
@@ -15,13 +16,14 @@ interface Props {
   sortable?: boolean
   orderByIndex?: number // index of the column in the orderBy array (0-based)
   orderBySize?: number // size of the orderBy array
-  ariaColIndex?: number // aria col index for the header
-  tabIndex?: number // tab index for the cell
+  ariaColIndex: number // aria col index for the header
+  ariaRowIndex: number // aria row index for the header
   className?: string // optional class name
 }
 
-export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, ariaColIndex, tabIndex, className, children }: Props) {
+export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
+  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
 
   // Get the column width from the context
   const { getColumnStyle, setColumnWidth, getColumnWidth } = useColumnWidth()

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -15,10 +15,12 @@ interface Props {
   sortable?: boolean
   orderByIndex?: number // index of the column in the orderBy array (0-based)
   orderBySize?: number // size of the orderBy array
+  ariaColIndex?: number // aria col index for the header
+  tabIndex?: number // tab index for the cell
   className?: string // optional class name
 }
 
-export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, className, children }: Props) {
+export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, ariaColIndex, tabIndex, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
 
   // Get the column width from the context
@@ -79,9 +81,8 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       data-order-by-index={orderBySize !== undefined ? orderByIndex : undefined}
       data-order-by-size={orderBySize}
       aria-description={description}
-      // 1-based index, +1 for the row header
-      // TODO(SL): don't hardcode it, but get it from the table context
-      aria-colindex={columnIndex + 2}
+      aria-colindex={ariaColIndex}
+      tabIndex={tabIndex}
       title={description}
       onClick={onClick}
       style={columnStyle}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -2,8 +2,8 @@ import { MouseEvent, ReactNode, useCallback, useEffect, useMemo, useRef } from '
 import { flushSync } from 'react-dom'
 import { Direction } from '../../helpers/sort.js'
 import { measureWidth } from '../../helpers/width.js'
+import { useCellNavigation } from '../../hooks/useCellsNavigation.js'
 import useColumnWidth from '../../hooks/useColumnWidth.js'
-import { useCellFocus } from '../../hooks/useFocus.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
 
 interface Props {
@@ -23,11 +23,11 @@ interface Props {
 
 export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const handleClick = useCallback((event: MouseEvent) => {
-    focusCell()
+    navigateToCell()
     onClick?.(event)
-  }, [onClick, focusCell])
+  }, [onClick, navigateToCell])
 
   // Get the column width from the context
   const { getColumnStyle, setColumnWidth, getColumnWidth } = useColumnWidth()

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -99,6 +99,8 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
         setWidth={setWidth}
         onDoubleClick={autoResize}
         width={width}
+        tabIndex={tabIndex}
+        navigateToCell={navigateToCell}
       />
     </th>
   )

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -86,6 +86,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       aria-sort={direction ?? (sortable ? 'none' : undefined)}
       data-order-by-index={orderBySize !== undefined ? orderByIndex : undefined}
       data-order-by-size={orderBySize}
+      aria-label={columnName}
       aria-description={description}
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -3,7 +3,7 @@ import { flushSync } from 'react-dom'
 import { Direction } from '../../helpers/sort.js'
 import { measureWidth } from '../../helpers/width.js'
 import useColumnWidth from '../../hooks/useColumnWidth.js'
-import { useTabIndex } from '../../hooks/useFocus.js'
+import { useCellFocus } from '../../hooks/useFocus.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
 
 interface Props {
@@ -23,7 +23,11 @@ interface Props {
 
 export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, sortable, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const handleClick = useCallback((event: MouseEvent) => {
+    focusCell()
+    onClick?.(event)
+  }, [onClick, focusCell])
 
   // Get the column width from the context
   const { getColumnStyle, setColumnWidth, getColumnWidth } = useColumnWidth()
@@ -86,7 +90,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}
       title={description}
-      onClick={onClick}
+      onClick={handleClick}
       style={columnStyle}
       className={className}
     >

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -67,6 +67,7 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
     <span
       role="separator"
       aria-orientation="vertical"
+      aria-busy={resizeClientX !== undefined}
       // TODO: make it focusable + keyboard accessible and add aria properties (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role)
       // Note that aria-valuenow would be helpful for tests.
       onDoubleClick={handleDoubleClick}

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -9,6 +9,7 @@ interface Props {
 }
 
 const keyboardShiftWidth = 10
+const minWidth = 1
 
 export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex, navigateToCell }: Props) {
   const [resizeClientX, setResizeClientX] = useState<number | undefined>(undefined)
@@ -101,9 +102,9 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       return
     }
     if (e.key === 'ArrowRight') {
-      setWidth?.(Math.max(1, width + keyboardShiftWidth))
+      setWidth?.(Math.max(minWidth, width + keyboardShiftWidth))
     } else if (e.key === 'ArrowLeft') {
-      setWidth?.(Math.max(1, width - keyboardShiftWidth))
+      setWidth?.(Math.max(minWidth, width - keyboardShiftWidth))
     }
   }, [onDoubleClick, resizeClientX, setWidth, width, activeKeyboard, navigateToCell])
 
@@ -114,7 +115,8 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       role="separator"
       aria-orientation="vertical"
       aria-busy={ariaBusy}
-      // Note that aria-valuenow would be helpful for tests.
+      aria-valuemin={minWidth}
+      aria-valuenow={width}
       aria-label="Resize column"
       onDoubleClick={handleDoubleClick}
       onMouseDown={onMouseDown}

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -4,10 +4,17 @@ interface Props {
   onDoubleClick?: () => void
   setWidth?: (width: number | undefined) => void
   width?: number
+  tabIndex?: number
+  navigateToCell?: () => void
 }
 
-export default function ColumnResizer({ onDoubleClick, setWidth, width }: Props) {
+export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex, navigateToCell }: Props) {
   const [resizeClientX, setResizeClientX] = useState<number | undefined>(undefined)
+
+  const handleDoubleClick = useCallback(() => {
+    navigateToCell?.()
+    onDoubleClick?.()
+  }, [onDoubleClick, navigateToCell])
 
   // Disable click event propagation
   const disableOnClick = useCallback((e: MouseEvent) => {
@@ -16,11 +23,12 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width }: Props)
 
   // Handle mouse down to start resizing
   const onMouseDown = useCallback((e: MouseEvent) => {
+    navigateToCell?.()
     e.stopPropagation()
     const nextResizeWidth = width ?? 0
     setResizeClientX(e.clientX - nextResizeWidth)
     setWidth?.(nextResizeWidth)
-  }, [setWidth, width])
+  }, [setWidth, width, navigateToCell])
 
   // Handle mouse move event during resizing
   useEffect(() => {
@@ -61,9 +69,10 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width }: Props)
       aria-orientation="vertical"
       // TODO: make it focusable + keyboard accessible and add aria properties (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role)
       // Note that aria-valuenow would be helpful for tests.
-      onDoubleClick={onDoubleClick}
+      onDoubleClick={handleDoubleClick}
       onMouseDown={onMouseDown}
       onClick={disableOnClick}
+      tabIndex={tabIndex}
     />
   )
 }

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback, useEffect, useState } from 'react'
+import { KeyboardEvent, MouseEvent, useCallback, useEffect, useState } from 'react'
 
 interface Props {
   onDoubleClick?: () => void
@@ -8,8 +8,11 @@ interface Props {
   navigateToCell?: () => void
 }
 
+const keyboardShiftWidth = 10
+
 export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex, navigateToCell }: Props) {
   const [resizeClientX, setResizeClientX] = useState<number | undefined>(undefined)
+  const [activeKeyboard, setActiveKeyboard] = useState<boolean>(false)
 
   const handleDoubleClick = useCallback(() => {
     navigateToCell?.()
@@ -63,16 +66,60 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
     }
   }, [resizeClientX, setWidth])
 
+  const onFocus = useCallback(() => {
+    setActiveKeyboard(true)
+  }, [])
+
+  const onBlur = useCallback(() => {
+    setActiveKeyboard(false)
+  }, [])
+
+  const onKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!activeKeyboard) {
+      // let the event propagate to the parent
+      return
+    }
+    e.stopPropagation()
+    if (resizeClientX !== undefined) {
+      // don't allow keyboard events when resizing with the mouse
+      return
+    }
+    if (e.key === 'Escape') {
+      // cancel resizing and focus the parent cell
+      setActiveKeyboard(false)
+      navigateToCell?.()
+      return
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      // autoresize
+      onDoubleClick?.()
+      return
+    }
+    if (width === undefined) {
+      // don't allow other keyboard events when width is not set
+      return
+    }
+    if (e.key === 'ArrowRight') {
+      setWidth?.(Math.max(1, width + keyboardShiftWidth))
+    } else if (e.key === 'ArrowLeft') {
+      setWidth?.(Math.max(1, width - keyboardShiftWidth))
+    }
+  }, [onDoubleClick, resizeClientX, setWidth, width, activeKeyboard, navigateToCell])
+
+  const ariaBusy = resizeClientX !== undefined || activeKeyboard
+
   return (
     <span
       role="separator"
       aria-orientation="vertical"
-      aria-busy={resizeClientX !== undefined}
-      // TODO: make it focusable + keyboard accessible and add aria properties (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role)
+      aria-busy={ariaBusy}
       // Note that aria-valuenow would be helpful for tests.
       onDoubleClick={handleDoubleClick}
       onMouseDown={onMouseDown}
       onClick={disableOnClick}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
       tabIndex={tabIndex}
     />
   )

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -80,7 +80,10 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       // let the event propagate to the parent
       return
     }
-    e.preventDefault()
+    if ([' ', 'ArrowRight', 'ArrowLeft'].includes(e.key)) {
+      // prevent scrolling the table
+      e.preventDefault()
+    }
     e.stopPropagation()
     if (resizeClientX !== undefined) {
       // don't allow keyboard events when resizing with the mouse

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -96,8 +96,8 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       return
     }
     if (e.key === 'Enter' || e.key === ' ') {
-      // autoresize
-      onDoubleClick?.()
+      // autoresize and exit keyboard mode
+      handleDoubleClick()
       return
     }
     if (width === undefined) {
@@ -109,7 +109,7 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
     } else if (e.key === 'ArrowLeft') {
       setWidth?.(Math.max(minWidth, width - keyboardShiftWidth))
     }
-  }, [onDoubleClick, resizeClientX, setWidth, width, activeKeyboard, navigateToCell])
+  }, [handleDoubleClick, resizeClientX, setWidth, width, activeKeyboard, navigateToCell])
 
   const ariaBusy = resizeClientX !== undefined || activeKeyboard
 

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -79,6 +79,7 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       // let the event propagate to the parent
       return
     }
+    e.preventDefault()
     e.stopPropagation()
     if (resizeClientX !== undefined) {
       // don't allow keyboard events when resizing with the mouse

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -115,6 +115,7 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       aria-orientation="vertical"
       aria-busy={ariaBusy}
       // Note that aria-valuenow would be helpful for tests.
+      aria-label="Resize column"
       onDoubleClick={handleDoubleClick}
       onMouseDown={onMouseDown}
       onClick={disableOnClick}

--- a/src/components/ColumnResizer/ColumnResizer.tsx
+++ b/src/components/ColumnResizer/ColumnResizer.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, MouseEvent, useCallback, useEffect, useState } from 'react'
+import { KeyboardEvent, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
 
 interface Props {
   onDoubleClick?: () => void
@@ -110,6 +110,13 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
 
   const ariaBusy = resizeClientX !== undefined || activeKeyboard
 
+  const ariaValueText = useMemo(() => {
+    if (width === undefined) {
+      return 'No width set.'
+    }
+    return `Width set to ${width} pixels.`
+  }, [width])
+
   return (
     <span
       role="separator"
@@ -117,7 +124,10 @@ export default function ColumnResizer({ onDoubleClick, setWidth, width, tabIndex
       aria-busy={ariaBusy}
       aria-valuemin={minWidth}
       aria-valuenow={width}
+      aria-valuetext={ariaValueText}
+      // TODO: use aria-labelledby and aria-describedby to allow translation
       aria-label="Resize column"
+      aria-description='Press "Enter" or "Space" to autoresize the column. Press "Escape" to cancel resizing. Press "ArrowRight" or "ArrowLeft" to resize the column by 10 pixels.'
       onDoubleClick={handleDoubleClick}
       onMouseDown={onMouseDown}
       onClick={disableOnClick}

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -164,8 +164,10 @@
   --cell-placeholder-z-index: 1;
   --cell-horizontal-padding: 12px;
 
-  --focus-border-color: black;
   --focus-border-width: 2px;
+  --focus-border-color: black;
+  --focus-error-border-color: red;
+  --focusable-border-color: #666;
 
   .table-scroll:focus {
     outline: none;
@@ -235,12 +237,24 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    &:focus {
-      outline-color: var(--focus-border-color);
-      outline-width: 1px;
+    outline-width: 1px;
+    outline-offset: -1px;
+
+    /* focusable cell (only one: the current navigation cell) */
+    &[tabindex="0"] {
+      outline-color: var(--focusable-border-color);
       outline-style: solid;
-      outline-offset: -1px;
       background-color: #f1f1f3;
+    }
+    /* focused cell: when the current navigation cell is focused. It should never be another cell */
+    &:focus {
+      outline-style: solid;
+      background-color: #f1f1f3;
+      /* in case a cell is focused but not focusable, show an error color */
+      outline-color: var(--focus-error-border-color);
+      &[tabindex="0"] {
+        outline-color: var(--focus-border-color);
+      }
     }
   }
 

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -165,9 +165,10 @@
   --cell-horizontal-padding: 12px;
 
   --focus-border-width: 2px;
-  --focus-border-color: black;
-  --focus-error-border-color: red;
+  --focus-border-color: #706fb1;
+  --focus-background-color: #efeef6;
   --focusable-border-color: #666;
+  --focusable-background-color: #f1f1f3;
 
   .table-scroll:focus {
     outline: none;
@@ -237,24 +238,21 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    outline-width: 1px;
-    outline-offset: -1px;
-
     /* focusable cell (only one: the current navigation cell) */
     &[tabindex="0"] {
-      outline-color: var(--focusable-border-color);
       outline-style: solid;
-      background-color: #f1f1f3;
+      outline-color: var(--focusable-border-color);
+      outline-width: 1px;
+      outline-offset: -1px;
+      background-color: var(--focusable-background-color);
     }
     /* focused cell: when the current navigation cell is focused. It should never be another cell */
     &:focus {
       outline-style: solid;
-      background-color: #f1f1f3;
-      /* in case a cell is focused but not focusable, show an error color */
-      outline-color: var(--focus-error-border-color);
-      &[tabindex="0"] {
-        outline-color: var(--focus-border-color);
-      }
+      outline-color: var(--focus-border-color);
+      outline-width: var(--focus-border-width);
+      outline-offset: -2px;
+      background-color: var(--focus-background-color);
     }
   }
 

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -18,6 +18,9 @@
     & > div {
       position: relative;
     }
+    /* avoid the row and column headers (sticky) to overlap the current navigation cell */
+    scroll-padding-inline-start: var(--row-number-width);
+    scroll-padding-block-start: var(--column-header-height);
   }
 
   table {

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -63,10 +63,10 @@
   /* column resize */
   thead [role="separator"] {
     position: absolute;
-    top: 0;
+    top: 1px;
     right: 0;
     bottom: 0;
-    width: 12px;
+    width: 8px;
     cursor: col-resize;
     background-color: #888;
     z-index: var(--header-separator-z-index, auto);
@@ -195,24 +195,25 @@
   thead {
     th {
       background-color: #f1f1f3;
-      border: none;
+      /* border: none; */
       border-bottom: 2px solid #c9c9c9;
       box-sizing: content-box;
       color: #444;
       height: 20px;
-      padding-top: 8px;
+      padding-top: 4px;
+      padding-bottom: 4px;
       top: -1px; /* fix 1px gap above thead */
 
       /* sorting is enabled - add space for the sort caret */
       &[aria-sort] {
-        padding-right: calc(var(--cell-horizontal-padding) + 8px);
+        padding-right: calc(var(--cell-horizontal-padding) + 12px);
       }
     }
   }
 
   th[aria-sort]::after {
-    right: 8px;
-    top: 8px;
+    right: 12px;
+    top: 4px;
     padding-left: 2px;
     background: none;
     color: #d5d4d6;
@@ -220,13 +221,6 @@
 
   th[data-order-by-index="0"]::after {
     color: inherit;
-  }
-
-  tbody tr:first-child {
-    td,
-    th {
-      border-top: 1px solid transparent;
-    }
   }
 
   /* cells */
@@ -257,9 +251,7 @@
 
   /* column resize */
   thead [role="separator"] {
-    background-color: inherit;
-    border-right: 1px solid #ddd;
-    width: 8px;
+    background-color: transparent;
     transition: background-color 0.2s ease;
   }
   thead [role="separator"]:hover {
@@ -343,22 +335,6 @@
     content: "427"; /* decorative purpose only - https://developer.mozilla.org/en-US/docs/Web/CSS/content#accessibility */
     filter: blur(4px);
   }
-
-  /* pending table state */
-  thead th::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
-    background-color: #706fb1;
-    z-index: var(--header-progress-z-index);
-  }
-  /* TODO(SL): add a global pending state? */
-  /* .pending thead th::before {
-    animation: shimmer 2s infinite linear;
-  } */
 
   /* don't hover on mobile */
   @media (hover: hover) {

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -241,7 +241,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    &:focus-visible {
+    &:focus {
       outline-color: var(--focus-border-color);
       outline-width: 1px;
       outline-style: solid;

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -240,6 +240,14 @@
     text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    &:focus-visible {
+      outline-color: var(--focus-border-color);
+      outline-width: 1px;
+      outline-style: solid;
+      outline-offset: -1px;
+      background-color: #f1f1f3;
+    }
   }
 
   /* row error */

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -275,6 +275,9 @@
       outline-offset: -2px;
       background-color: #aab;
     }
+    &[aria-busy="true"] {
+      background-color: #ddd;
+    }
   }
 
   /* row numbers */

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -265,9 +265,16 @@
   thead [role="separator"] {
     background-color: transparent;
     transition: background-color 0.2s ease;
-  }
-  thead [role="separator"]:hover {
-    background-color: #aab;
+    &:hover {
+      background-color: #aab;
+    }
+    &:focus {
+      outline-style: solid;
+      outline-color: var(--focus-border-color);
+      outline-width: var(--focus-border-width);
+      outline-offset: -2px;
+      background-color: #aab;
+    }
   }
 
   /* row numbers */

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -8,13 +8,15 @@ import HighTable from './HighTable.js'
 Element.prototype.scrollIntoView = vi.fn()
 
 const data: DataFrame = {
-  header: ['ID', 'Count'],
+  header: ['ID', 'Count', 'Double', 'Triple'],
   numRows: 1000,
   rows: ({ start, end }) => Array.from({ length: end - start }, (_, index) => ({
     index: wrapResolved(index + start),
     cells: {
       ID: wrapResolved(`row ${index + start}`),
       Count: wrapResolved(1000 - start - index),
+      Double: wrapResolved((1000 - start - index) * 2),
+      Triple: wrapResolved((1000 - start - index) * 3),
     },
   })),
 }
@@ -139,7 +141,7 @@ describe('When sorted, HighTable', () => {
     expect(selectionCell.textContent).toBe(rowNumber)
 
     const columns = within(row).getAllByRole('cell')
-    expect(columns).toHaveLength(2)
+    expect(columns).toHaveLength(4)
     expect(columns[0]?.textContent).toBe(ID)
     expect(columns[1]?.textContent).toBe(Count)
   }
@@ -570,7 +572,7 @@ describe('HighTable localstorage', () => {
     }
     expect(header.style.maxWidth).toEqual(`${initialWidth}px`)
     expect(measureWidth).toHaveBeenCalled()
-    expect(localStorage.getItem('key:column-widths')).toEqual(JSON.stringify([initialWidth, initialWidth]))
+    expect(localStorage.getItem('key:column-widths')).toEqual(JSON.stringify([initialWidth, initialWidth, initialWidth, initialWidth]))
   })
   it('saves nothing on initialization if cacheKey is not provided', () => {
     localStorage.clear()
@@ -588,20 +590,20 @@ describe('HighTable localstorage', () => {
   it('is used to load previously saved column widths', () => {
     localStorage.clear()
     const savedWidth = initialWidth * 2
-    localStorage.setItem('key:column-widths', JSON.stringify([savedWidth, savedWidth]))
+    localStorage.setItem('key:column-widths', JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
 
     const { getAllByRole } = render(<HighTable data={data} cacheKey="key" />)
     const header = getAllByRole('columnheader')[0]
     if (!header) {
       throw new Error('Header should not be null')
     }
-    expect(localStorage.getItem('key:column-widths')).toEqual(JSON.stringify([savedWidth, savedWidth]))
+    expect(localStorage.getItem('key:column-widths')).toEqual(JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
   })
   it('is updated if new data are loaded', () => {
     localStorage.clear()
     const savedWidth = initialWidth * 2
-    localStorage.setItem('key:column-widths', JSON.stringify([savedWidth, savedWidth]))
+    localStorage.setItem('key:column-widths', JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
 
     const { getAllByRole, rerender } = render(<HighTable data={data} cacheKey="key" />)
 
@@ -656,6 +658,67 @@ describe('Navigating Hightable with the keyboard', () => {
       const scrollableDiv = getByLabelText('Virtual-scroll table')
       await user.keyboard(key)
       expect(document.activeElement).toBe(scrollableDiv)
+    })
+  })
+
+  function getFocusCoordinates() {
+    const focusedElement = document.activeElement
+    expect(focusedElement).toBeDefined()
+    if (!focusedElement) {
+      throw new Error('Focused element not found')
+    }
+    const rowIndex = focusedElement.closest('[role="row"]')?.getAttribute('aria-rowindex')
+    const colIndex = focusedElement.getAttribute('aria-colindex')
+    expect(rowIndex).toBeDefined()
+    expect(colIndex).toBeDefined()
+    return { rowIndex: Number(rowIndex), colIndex: Number(colIndex) }
+  }
+
+  const rowIndex = 4
+  const colIndex = 3
+  const pageSize = 2
+  const firstRow = 1
+  // const lastRow = data.numRows + 1 // see comments below
+  const firstCol = 1
+  const lastCol = data.header.length + 1
+  describe('When the cell (4,3) is focused', () => {
+    it.each([
+      ['{ArrowRight}', rowIndex, colIndex + 1],
+      ['{Control>}{ArrowRight}{/Control}', rowIndex, lastCol],
+      ['{ArrowLeft}', rowIndex, colIndex - 1],
+      ['{Control>}{ArrowLeft}{/Control}', rowIndex, firstCol],
+      ['{ArrowUp}', rowIndex - 1, colIndex],
+      ['{Control>}{ArrowUp}{/Control}', firstRow, colIndex],
+      ['{ArrowDown}', rowIndex + 1, colIndex],
+      // ['{Control>}{ArrowDown}{/Control}', lastRow, 3], // Cannot be tested because it relies on scroll
+      ['{PageUp}', rowIndex - pageSize, colIndex],
+      ['{Shift>}{ }{/Shift}', rowIndex - pageSize, colIndex],
+      ['{PageDown}', rowIndex + pageSize, colIndex],
+      ['{ }', rowIndex + pageSize, colIndex],
+      ['{Home}', rowIndex, firstCol],
+      ['{Control>}{Home}{/Control}', firstRow, firstCol],
+      ['{End}', rowIndex, lastCol],
+      // ['{Control>}{End}{/Control}', lastRow, lastCol], // Cannot be tested because it relies on scroll
+
+      // stop at the borders
+      ['{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}', rowIndex, lastCol],
+      ['{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}', rowIndex, firstCol],
+      ['{ArrowUp}{ArrowUp}{ArrowUp}{ArrowUp}', firstRow, colIndex],
+      // don't test ArrowDown because it relies on scroll
+      ['{PageUp}{PageUp}{PageUp}{PageUp}', firstRow, colIndex],
+      // don't test PageDown because it relies on scroll
+      ['{Home}{Home}{Home}{Home}', rowIndex, firstCol],
+      ['{End}{End}{End}{End}', rowIndex, lastCol],
+      ['{Control>}{Home}{Home}{Home}{Home}{/Control}', firstRow, firstCol],
+      // ['{Control>}{End}{End}{End}{End}{/Control}', lastRow, lastCol], // Cannot be tested because it relies on scroll
+    ])('pressing "%s" moves the focus to the cell (%s, %s)', async (key, expectedRowIndex, expectedColIndex) => {
+      const { user } = render(<HighTable data={data} padding={pageSize} />)
+      // focus the cell (4, 3)
+      await user.keyboard('{Tab}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowRight}{ArrowRight}')
+      expect(getFocusCoordinates()).toEqual({ rowIndex, colIndex })
+
+      await user.keyboard(key)
+      expect(getFocusCoordinates()).toEqual({ rowIndex: expectedRowIndex, colIndex: expectedColIndex })
     })
   })
 })

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -659,6 +659,18 @@ describe('Navigating Hightable with the keyboard', () => {
       await user.keyboard(key)
       expect(document.activeElement).toBe(scrollableDiv)
     })
+    it('pressing "Tab", then "Tab", then "Shift+Tab", then "Shift+Tab" moves the focus back to the scrollable div', async () => {
+      const { user, getByLabelText } = render(<HighTable data={data} />)
+      const scrollableDiv = getByLabelText('Virtual-scroll table')
+      await user.keyboard('{Tab}')
+      expect(document.activeElement).not.toBe(scrollableDiv)
+      await user.keyboard('{Tab}')
+      expect(document.activeElement).not.toBe(scrollableDiv)
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(document.activeElement).not.toBe(scrollableDiv)
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(document.activeElement).toBe(scrollableDiv)
+    })
   })
 
   function getFocusCoordinates() {

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -751,5 +751,23 @@ describe('Navigating Hightable with the keyboard', () => {
       await user.keyboard('{Shift>}{Tab}{/Shift}')
       expect(document.activeElement).toBe(cell)
     })
+
+    it('the column resizer is activated on focus, and loses focus when Escape is pressed', async () => {
+      const { user } = render(<HighTable data={data} />)
+      // go to the column resizer
+      await user.keyboard('{Tab}{ArrowRight}')
+      const cell = document.activeElement
+      await user.keyboard('{Tab}')
+      // press Enter to activate the column resizer
+      const separator = document.activeElement
+      if (!separator) {
+        throw new Error('Separator is null')
+      }
+      expect(separator.getAttribute('aria-busy')).toBe('true')
+      // escape to deactivate the column resizer
+      await user.keyboard('{Escape}')
+      expect(separator.getAttribute('aria-busy')).toBe('false')
+      expect(document.activeElement).toBe(cell)
+    })
   })
 })

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -769,5 +769,42 @@ describe('Navigating Hightable with the keyboard', () => {
       expect(separator.getAttribute('aria-busy')).toBe('false')
       expect(document.activeElement).toBe(cell)
     })
+
+    it('the column resizer changes the column width when ArrowRight or ArrowLeft are pressed', async () => {
+      const { user } = render(<HighTable data={data} />)
+      // go to the column resizer
+      await user.keyboard('{Tab}{ArrowRight}{Tab}')
+      const separator = document.activeElement
+      if (!separator) {
+        throw new Error('Separator is null')
+      }
+      const value = separator.getAttribute('aria-valuenow')
+      // the column measurement is mocked
+      expect(value).toBe(initialWidth.toString())
+      await user.keyboard('{ArrowRight}')
+      expect(separator.getAttribute('aria-valuenow')).toBe((initialWidth + 10).toString())
+      await user.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}')
+      expect(separator.getAttribute('aria-valuenow')).toBe((initialWidth - 20).toString())
+    })
+
+    it.for(['{ }', '{Enter}'])('the column resizer autosizes the column and exits resize mode when %s is pressed', async (key) => {
+      const { user } = render(<HighTable data={data} />)
+      // go to the column resizer
+      await user.keyboard('{Tab}{ArrowRight}')
+      const cell = document.activeElement
+      await user.keyboard('{Tab}')
+      const separator = document.activeElement
+      if (!separator) {
+        throw new Error('Separator is null')
+      }
+      const value = separator.getAttribute('aria-valuenow')
+      // the column measurement is mocked
+      expect(value).toBe(initialWidth.toString())
+      await user.keyboard('{ArrowRight}')
+      expect(separator.getAttribute('aria-valuenow')).toBe((initialWidth + 10).toString())
+      await user.keyboard(key)
+      expect(separator.getAttribute('aria-valuenow')).toBe(initialWidth.toString())
+      expect(document.activeElement).toBe(cell)
+    })
   })
 })

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -733,4 +733,23 @@ describe('Navigating Hightable with the keyboard', () => {
       expect(getFocusCoordinates()).toEqual({ rowIndex: expectedRowIndex, colIndex: expectedColIndex })
     })
   })
+
+  describe('When a header cell is focused', () => {
+    it('the column resizer and the header cell are focusable', async () => {
+      const { user } = render(<HighTable data={data} />)
+      // go to the header cell (ID)
+      await user.keyboard('{Tab}{ArrowRight}')
+      const cell = document.activeElement
+      // Tab focuses the column resizer
+      await user.keyboard('{Tab}')
+      const focusedElement = document.activeElement
+      if (!focusedElement) {
+        throw new Error('Focused element not found')
+      }
+      expect(focusedElement.getAttribute('role')).toBe('separator')
+      // Shift+Tab focuses the header cell again
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(document.activeElement).toBe(cell)
+    })
+  })
 })

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -616,3 +616,46 @@ describe('HighTable localstorage', () => {
     expect(header.style.maxWidth).toEqual(`${initialWidth}px`)
   })
 })
+
+describe('Navigating Hightable with the keyboard', () => {
+  describe('On mount, the scrollable div', () => {
+    it('is focused by default', () => {
+      const { queryByLabelText } = render(<HighTable data={data} />)
+      const scrollableDiv = queryByLabelText('Virtual-scroll table')
+      expect(scrollableDiv).toBeDefined()
+      expect(document.activeElement).toBe(scrollableDiv)
+    })
+    it('is not focused if focus prop is false', () => {
+      const { queryByLabelText } = render(<HighTable data={data} focus={false} />)
+      const scrollableDiv = queryByLabelText('Virtual-scroll table')
+      expect(scrollableDiv).toBeDefined()
+      expect(document.activeElement).not.toBe(scrollableDiv)
+    })
+  })
+
+  describe('When the scrollable div is focused', () => {
+    it.for(['{Tab}', '{ }', '{Enter}'])('moves the focus to the first cell when pressing "%s"', async (key) => {
+      const { user } = render(<HighTable data={data} />)
+      await user.keyboard(key)
+      const focusedElement = document.activeElement
+      expect(focusedElement).toBeDefined()
+      if (!focusedElement) {
+        throw new Error('Focused element not found')
+      }
+      expect(focusedElement.getAttribute('aria-colindex')).toBe('1')
+      expect(focusedElement.closest('[role="row"]')?.getAttribute('aria-rowindex')).toBe('1')
+    })
+    it.for(['{Shift>}{Tab}{/Shift}'])('moves the focus outside of the table when pressing "%s"', async (key) => {
+      const { user } = render(<HighTable data={data} />)
+      await user.keyboard(key)
+      const focusedElement = document.activeElement
+      expect(focusedElement?.localName).toBe('body')
+    })
+    it.for(['{ArrowUp}', '{ArrowDown}', '{ArrowLeft}', '{ArrowRight}'])('scroll while keeping the focus on the scrollable div when pressing "%s"', async (key) => {
+      const { user, getByLabelText } = render(<HighTable data={data} />)
+      const scrollableDiv = getByLabelText('Virtual-scroll table')
+      await user.keyboard(key)
+      expect(document.activeElement).toBe(scrollableDiv)
+    })
+  })
+})

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -5,6 +5,8 @@ import { wrapResolved } from '../../utils/promise.js'
 import { render } from '../../utils/userEvent.js'
 import HighTable from './HighTable.js'
 
+Element.prototype.scrollIntoView = vi.fn()
+
 const data: DataFrame = {
   header: ['ID', 'Count'],
   numRows: 1000,

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -114,7 +114,7 @@ export function HighTableInner({
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
-  const { onKeyDown, rowIndex, colIndex } = useCellsNavigation()
+  const { shouldFocus, onTableKeyDown, onScrollKeyDown, rowIndex, colIndex } = useCellsNavigation()
   const [lastCellPosition, setLastCellPosition] = useState({ rowIndex, colIndex })
   const [numRows, setNumRows] = useState(data.numRows)
 
@@ -239,7 +239,7 @@ export function HighTableInner({
       // don't scroll if the slice is not ready
       return
     }
-    if (lastCellPosition.rowIndex === rowIndex && lastCellPosition.colIndex === colIndex) {
+    if (!shouldFocus && lastCellPosition.rowIndex === rowIndex && lastCellPosition.colIndex === colIndex) {
       // don't scroll if the navigation cell is unchanged
       // occurs when the user is scrolling with the mouse for example, and the
       // cell exits the viewport: don't want to scroll back to it
@@ -262,7 +262,7 @@ export function HighTableInner({
       // scroll to the cell
       scroller.scrollTop = nextScrollTop
     }
-  }, [rowIndex, colIndex, slice, lastCellPosition, padding])
+  }, [rowIndex, colIndex, slice, lastCellPosition, padding, shouldFocus])
 
   // handle scrolling and window resizing
   useEffect(() => {
@@ -453,7 +453,7 @@ export function HighTableInner({
   const ariaRowCount = numRows + 1 // don't forget the header row
   return (
     <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
-      <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption" style={tableScrollStyle}>
+      <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption" style={tableScrollStyle} onKeyDown={onScrollKeyDown} tabIndex={0}>
         <div style={{ height: `${scrollHeight}px` }}>
           <table
             aria-readonly={true}
@@ -462,7 +462,7 @@ export function HighTableInner({
             aria-multiselectable={showSelectionControls}
             role='grid'
             style={{ top: `${offsetTop}px` }}
-            onKeyDown={onKeyDown}
+            onKeyDown={onTableKeyDown}
           >
             <caption id="caption" hidden>Virtual-scroll table</caption>
             <thead role="rowgroup">

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -113,8 +113,8 @@ export function HighTableInner({
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
-  const { onKeyDown, rowIndex } = useCellsNavigation()
-  const [lastRowIndex, setLastRowIndex] = useState(rowIndex)
+  const { onKeyDown, rowIndex, colIndex } = useCellsNavigation()
+  const [lastCellPosition, setLastCellPosition] = useState({ rowIndex, colIndex })
 
   // TODO(SL): remove this state and only rely on the data frame for these operations?
   // ie. cache the previous sort indexes in the data frame itself
@@ -236,13 +236,13 @@ export function HighTableInner({
       // don't scroll if the slice is not ready
       return
     }
-    if (lastRowIndex === rowIndex) {
-      // don't scroll if the row index is unchanged
-      // occurs when the user is scrolling with the mouse for example, and the focused
+    if (lastCellPosition.rowIndex === rowIndex && lastCellPosition.colIndex === colIndex) {
+      // don't scroll if the navigation cell is unchanged
+      // occurs when the user is scrolling with the mouse for example, and the
       // cell exits the viewport: don't want to scroll back to it
       return
     }
-    setLastRowIndex(rowIndex)
+    setLastCellPosition({ rowIndex, colIndex })
     const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
     if (tableIndex < slice.offset || tableIndex >= slice.offset + slice.rows.length) {
       // scroll to the estimated position of the cell (and wait for the cell to be fetched and rendered)
@@ -253,7 +253,7 @@ export function HighTableInner({
         scroller.scrollTop = rowTop
       }
     }
-  }, [rowIndex, slice, lastRowIndex])
+  }, [rowIndex, colIndex, slice, lastCellPosition, padding])
 
   // handle scrolling and window resizing
   useEffect(() => {

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -49,6 +49,7 @@ interface Props {
 }
 
 const defaultPadding = 20
+const ariaOffset = 2 // 1-based index, +1 for the header
 
 /**
  * Render a table with streaming rows on demand from a DataFrame.
@@ -242,7 +243,7 @@ export function HighTableInner({
       return
     }
     setLastCellPosition({ rowIndex, colIndex })
-    const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
+    const tableIndex = rowIndex - ariaOffset
     const scroller = scrollRef.current
     if (!scroller) {
       // don't scroll if the scroller is not ready
@@ -472,7 +473,7 @@ export function HighTableInner({
             <tbody role="rowgroup">
               {prePadding.map((_, prePaddingIndex) => {
                 const tableIndex = offset - prePadding.length + prePaddingIndex
-                const ariaRowIndex = tableIndex + 2 // 1-based index, +1 for the header
+                const ariaRowIndex = tableIndex + ariaOffset
                 return (
                   <Row key={tableIndex} ariaRowIndex={ariaRowIndex}>
                     <RowHeader style={cornerStyle} ariaColIndex={1} ariaRowIndex={ariaRowIndex} />
@@ -484,7 +485,7 @@ export function HighTableInner({
                 const inferredDataIndex = orderBy === undefined || orderBy.length === 0 ? tableIndex : undefined
                 const dataIndex = row.index ?? inferredDataIndex
                 const selected = isRowSelected(dataIndex) ?? false
-                const ariaRowIndex = tableIndex + 2 // 1-based index, +1 for the header
+                const ariaRowIndex = tableIndex + ariaOffset
                 return (
                   <Row
                     key={tableIndex}
@@ -514,7 +515,7 @@ export function HighTableInner({
                         columnIndex={columnIndex}
                         hasResolved={hasResolved}
                         className={columnClassNames[columnIndex]}
-                        ariaColIndex={columnIndex + 2}
+                        ariaColIndex={columnIndex + ariaOffset}
                         ariaRowIndex={ariaRowIndex}
                       />
                     })}
@@ -523,7 +524,7 @@ export function HighTableInner({
               })}
               {postPadding.map((_, postPaddingIndex) => {
                 const tableIndex = offset + rowsLength + postPaddingIndex
-                const ariaRowIndex = tableIndex + 2 // 1-based index, +1 for the header
+                const ariaRowIndex = tableIndex + ariaOffset
                 return (
                   <Row key={tableIndex} ariaRowIndex={ariaRowIndex}>
                     <RowHeader style={cornerStyle} ariaColIndex={1} ariaRowIndex={ariaRowIndex} />

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -49,6 +49,7 @@ interface Props {
 }
 
 const defaultPadding = 20
+const defaultOverscan = 20
 const ariaOffset = 2 // 1-based index, +1 for the header
 
 /**
@@ -79,7 +80,7 @@ export default function HighTable(props: Props) {
  */
 export function HighTableInner({
   data,
-  overscan = 20,
+  overscan = defaultOverscan,
   padding = defaultPadding,
   focus = true,
   orderBy: propOrderBy,

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -48,6 +48,8 @@ interface Props {
   styled?: boolean // use styled component? (default true)
 }
 
+const defaultPadding = 20
+
 /**
  * Render a table with streaming rows on demand from a DataFrame.
  *
@@ -62,7 +64,7 @@ export default function HighTable(props: Props) {
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return (
     <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
-      <FocusProvider colCount={ariaColCount} rowCount={ariaRowCount}>
+      <FocusProvider colCount={ariaColCount} rowCount={ariaRowCount} rowPadding={props.padding ?? defaultPadding}>
         <HighTableInner {...props} />
       </FocusProvider>
     </ColumnWidthProvider>
@@ -77,7 +79,7 @@ export default function HighTable(props: Props) {
 export function HighTableInner({
   data,
   overscan = 20,
-  padding = 20,
+  padding = defaultPadding,
   focus = true,
   orderBy: propOrderBy,
   onOrderByChange: propOnOrderByChange,

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -231,10 +231,6 @@ export function HighTableInner({
 
   // scroll vertically to the focused cell if needed
   useEffect(() => {
-    if (rowIndex === 1) {
-      // don't scroll if the cell is in the first row or column
-      return
-    }
     if (!slice) {
       // don't scroll if the slice is not ready
       return

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -4,8 +4,8 @@ import { PartialRow } from '../../helpers/row.js'
 import { Selection, areAllSelected, isSelected, toggleAll, toggleIndexInSelection, toggleRangeInSelection, toggleRangeInTable } from '../../helpers/selection.js'
 import { OrderBy, areEqualOrderBy } from '../../helpers/sort.js'
 import { leftCellStyle } from '../../helpers/width.js'
+import { CellsNavigationProvider, useCellsNavigation } from '../../hooks/useCellsNavigation.js'
 import { ColumnWidthProvider } from '../../hooks/useColumnWidth.js'
-import { FocusProvider, useFocus } from '../../hooks/useFocus.js'
 import { useInputState } from '../../hooks/useInputState.js'
 import { stringify as stringifyDefault } from '../../utils/stringify.js'
 import { throttle } from '../../utils/throttle.js'
@@ -64,9 +64,9 @@ export default function HighTable(props: Props) {
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return (
     <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
-      <FocusProvider colCount={ariaColCount} rowCount={ariaRowCount} rowPadding={props.padding ?? defaultPadding}>
+      <CellsNavigationProvider colCount={ariaColCount} rowCount={ariaRowCount} rowPadding={props.padding ?? defaultPadding}>
         <HighTableInner {...props} />
-      </FocusProvider>
+      </CellsNavigationProvider>
     </ColumnWidthProvider>
   )
 }
@@ -113,7 +113,7 @@ export function HighTableInner({
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
-  const { onKeyDown, rowIndex } = useFocus()
+  const { onKeyDown, rowIndex } = useCellsNavigation()
   const [lastRowIndex, setLastRowIndex] = useState(rowIndex)
 
   // TODO(SL): remove this state and only rely on the data frame for these operations?

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { CSSProperties, KeyboardEvent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DataFrame } from '../../helpers/dataframe.js'
 import { PartialRow } from '../../helpers/row.js'
 import { Selection, areAllSelected, isSelected, toggleAll, toggleIndexInSelection, toggleRangeInSelection, toggleRangeInTable } from '../../helpers/selection.js'
@@ -447,6 +447,13 @@ export function HighTableInner({
       '--row-number-width': `${rowHeaderWidth}px`,
     } as CSSProperties
   }, [rowHeaderWidth])
+  const restrictedOnScrollKeyDown = useCallback((event: KeyboardEvent) => {
+    if (event.target !== scrollRef.current) {
+      // don't handle the event if the target is not the scroller
+      return
+    }
+    onScrollKeyDown?.(event)
+  }, [onScrollKeyDown])
 
   // don't render table if header is empty
   if (!data.header.length) return
@@ -455,7 +462,7 @@ export function HighTableInner({
   const ariaRowCount = numRows + 1 // don't forget the header row
   return (
     <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
-      <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption" style={tableScrollStyle} onKeyDown={onScrollKeyDown} tabIndex={0}>
+      <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption" style={tableScrollStyle} onKeyDown={restrictedOnScrollKeyDown} tabIndex={0}>
         <div style={{ height: `${scrollHeight}px` }}>
           <table
             aria-readonly={true}

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -48,6 +48,14 @@ interface Props {
   styled?: boolean // use styled component? (default true)
 }
 
+/**
+ * Render a table with streaming rows on demand from a DataFrame.
+ *
+ * orderBy: the order used to fetch the rows. If set, the component is controlled, and the property cannot be unset (undefined) later. If undefined, the component is uncontrolled (internal state). If the data cannot be sorted, it's ignored.
+ * onOrderByChange: the callback to call when the order changes. If undefined, the component order is read-only if controlled (orderBy is set), or disabled if not (or if the data cannot be sorted).
+ * selection: the selected rows and the anchor row. If set, the component is controlled, and the property cannot be unset (undefined) later. If undefined, the component is uncontrolled (internal state).
+ * onSelectionChange: the callback to call when the selection changes. If undefined, the component selection is read-only if controlled (selection is set), or disabled if not.
+ */
 export default function HighTable(props: Props) {
   const { data, cacheKey } = props
   const ariaColCount = data.header.length + 1 // don't forget the selection column
@@ -62,12 +70,9 @@ export default function HighTable(props: Props) {
 }
 
 /**
- * Render a table with streaming rows on demand from a DataFrame.
- *
- * orderBy: the order used to fetch the rows. If set, the component is controlled, and the property cannot be unset (undefined) later. If undefined, the component is uncontrolled (internal state). If the data cannot be sorted, it's ignored.
- * onOrderByChange: the callback to call when the order changes. If undefined, the component order is read-only if controlled (orderBy is set), or disabled if not (or if the data cannot be sorted).
- * selection: the selected rows and the anchor row. If set, the component is controlled, and the property cannot be unset (undefined) later. If undefined, the component is uncontrolled (internal state).
- * onSelectionChange: the callback to call when the selection changes. If undefined, the component selection is read-only if controlled (selection is set), or disabled if not.
+ * The main purpose of extracting HighTableInner from HighTable is to
+ * separate the context providers from the main component. It will also
+ * remove the need to reindent the code if adding a new context provide.
  */
 export function HighTableInner({
   data,

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -244,14 +244,25 @@ export function HighTableInner({
     }
     setLastCellPosition({ rowIndex, colIndex })
     const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
+    const scroller = scrollRef.current
+    if (!scroller) {
+      // don't scroll if the scroller is not ready
+      return
+    }
+    let nextScrollTop = scroller.scrollTop
+    // if tableIndex outside of the slice, scroll to the estimated position of the cell,
+    // to wait for the cell to be fetched and rendered
     if (tableIndex < slice.offset || tableIndex >= slice.offset + slice.rows.length) {
-      // scroll to the estimated position of the cell (and wait for the cell to be fetched and rendered)
-      const rowTop = tableIndex * rowHeight
-      const scroller = scrollRef.current
-      if (scroller) {
-        // scroll to the cell
-        scroller.scrollTop = rowTop
-      }
+      nextScrollTop = tableIndex * rowHeight
+    }
+    // if the cell is under the header, scroll up to show it
+    if (nextScrollTop > tableIndex * rowHeight - rowHeight / 2) {
+      nextScrollTop -= rowHeight
+    }
+
+    if (nextScrollTop !== scroller.scrollTop) {
+      // scroll to the cell
+      scroller.scrollTop = nextScrollTop
     }
   }, [rowIndex, colIndex, slice, lastCellPosition, padding])
 

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -114,7 +114,7 @@ export function HighTableInner({
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
-  const { shouldFocus, onTableKeyDown, onScrollKeyDown, rowIndex, colIndex } = useCellsNavigation()
+  const { enterCellsNavigation, setEnterCellsNavigation, onTableKeyDown, onScrollKeyDown, rowIndex, colIndex } = useCellsNavigation()
   const [lastCellPosition, setLastCellPosition] = useState({ rowIndex, colIndex })
   const [numRows, setNumRows] = useState(data.numRows)
 
@@ -239,12 +239,13 @@ export function HighTableInner({
       // don't scroll if the slice is not ready
       return
     }
-    if (!shouldFocus && lastCellPosition.rowIndex === rowIndex && lastCellPosition.colIndex === colIndex) {
+    if (!enterCellsNavigation && lastCellPosition.rowIndex === rowIndex && lastCellPosition.colIndex === colIndex) {
       // don't scroll if the navigation cell is unchanged
       // occurs when the user is scrolling with the mouse for example, and the
       // cell exits the viewport: don't want to scroll back to it
       return
     }
+    setEnterCellsNavigation?.(false)
     setLastCellPosition({ rowIndex, colIndex })
     const tableIndex = rowIndex - ariaOffset
     const scroller = scrollRef.current
@@ -262,7 +263,7 @@ export function HighTableInner({
       // scroll to the cell
       scroller.scrollTop = nextScrollTop
     }
-  }, [rowIndex, colIndex, slice, lastCellPosition, padding, shouldFocus])
+  }, [rowIndex, colIndex, slice, lastCellPosition, padding, enterCellsNavigation, setEnterCellsNavigation])
 
   // handle scrolling and window resizing
   useEffect(() => {

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -5,6 +5,7 @@ import { Selection, areAllSelected, isSelected, toggleAll, toggleIndexInSelectio
 import { OrderBy, areEqualOrderBy } from '../../helpers/sort.js'
 import { leftCellStyle } from '../../helpers/width.js'
 import { ColumnWidthProvider } from '../../hooks/useColumnWidth.js'
+import { FocusProvider } from '../../hooks/useFocus.js'
 import { useInputState } from '../../hooks/useInputState.js'
 import { stringify as stringifyDefault } from '../../utils/stringify.js'
 import { throttle } from '../../utils/throttle.js'
@@ -375,100 +376,102 @@ export default function HighTable({
   const ariaColCount = data.header.length + 1 // don't forget the selection column
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
-    <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
-      <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption">
-        <div style={{ height: `${scrollHeight}px` }}>
-          <table
-            aria-readonly={true}
-            aria-colcount={ariaColCount}
-            aria-rowcount={ariaRowCount}
-            aria-multiselectable={showSelectionControls}
-            ref={tableRef}
-            role='grid'
-            style={{ top: `${offsetTop}px` }}
-          >
-            <caption id="caption" hidden>Virtual-scroll table</caption>
-            <thead role="rowgroup">
-              <Row ariaRowIndex={1} >
-                <TableCorner
-                  onClick={getOnSelectAllRows()}
-                  checked={allRowsSelected}
-                  showCheckBox={showCornerSelection}
-                  style={cornerStyle}
-                  ariaColIndex={1}
-                >&nbsp;</TableCorner>
-                <TableHeader
-                  dataReady={hasCompleteRow}
-                  header={data.header}
-                  orderBy={orderBy}
-                  onOrderByChange={onOrderByChange}
-                  sortable={enableOrderByInteractions}
-                  columnClassNames={columnClassNames}
-                />
-              </Row>
-            </thead>
-            <tbody role="rowgroup">
-              {prePadding.map((_, prePaddingIndex) => {
-                const tableIndex = offset - prePadding.length + prePaddingIndex
-                return (
-                  <Row key={tableIndex} ariaRowIndex={tableIndex + 2} >
-                    <RowHeader style={cornerStyle} ariaColIndex={1} />
-                  </Row>
-                )
-              })}
-              {slice?.rows.map((row, rowIndex) => {
-                const tableIndex = slice.offset + rowIndex
-                const inferredDataIndex = orderBy === undefined || orderBy.length === 0 ? tableIndex : undefined
-                const dataIndex = row.index ?? inferredDataIndex
-                const selected = isRowSelected(dataIndex) ?? false
-                return (
-                  <Row
-                    key={tableIndex}
-                    selected={selected}
-                    ariaRowIndex={tableIndex + 2}
-                    title={rowError(row, data.header.length)}
-                  >
-                    <RowHeader
-                      busy={dataIndex === undefined}
-                      style={cornerStyle}
-                      onClick={dataIndex === undefined ? undefined : getOnSelectRowClick({ tableIndex, dataIndex })}
-                      checked={selected}
-                      showCheckBox={showSelection}
-                      ariaColIndex={1}
-                    >{formatRowNumber(dataIndex)}</RowHeader>
-                    {data.header.map((column, columnIndex) => {
+    <FocusProvider>
+      <div className={`${styles.hightable} ${styled ? styles.styled : ''} ${className}`}>
+        <div className={styles.tableScroll} ref={scrollRef} role="group" aria-labelledby="caption">
+          <div style={{ height: `${scrollHeight}px` }}>
+            <table
+              aria-readonly={true}
+              aria-colcount={ariaColCount}
+              aria-rowcount={ariaRowCount}
+              aria-multiselectable={showSelectionControls}
+              ref={tableRef}
+              role='grid'
+              style={{ top: `${offsetTop}px` }}
+            >
+              <caption id="caption" hidden>Virtual-scroll table</caption>
+              <thead role="rowgroup">
+                <Row ariaRowIndex={1} >
+                  <TableCorner
+                    onClick={getOnSelectAllRows()}
+                    checked={allRowsSelected}
+                    showCheckBox={showCornerSelection}
+                    style={cornerStyle}
+                    ariaColIndex={1}
+                  >&nbsp;</TableCorner>
+                  <TableHeader
+                    dataReady={hasCompleteRow}
+                    header={data.header}
+                    orderBy={orderBy}
+                    onOrderByChange={onOrderByChange}
+                    sortable={enableOrderByInteractions}
+                    columnClassNames={columnClassNames}
+                  />
+                </Row>
+              </thead>
+              <tbody role="rowgroup">
+                {prePadding.map((_, prePaddingIndex) => {
+                  const tableIndex = offset - prePadding.length + prePaddingIndex
+                  return (
+                    <Row key={tableIndex} ariaRowIndex={tableIndex + 2} >
+                      <RowHeader style={cornerStyle} ariaColIndex={1} />
+                    </Row>
+                  )
+                })}
+                {slice?.rows.map((row, rowIndex) => {
+                  const tableIndex = slice.offset + rowIndex
+                  const inferredDataIndex = orderBy === undefined || orderBy.length === 0 ? tableIndex : undefined
+                  const dataIndex = row.index ?? inferredDataIndex
+                  const selected = isRowSelected(dataIndex) ?? false
+                  return (
+                    <Row
+                      key={tableIndex}
+                      selected={selected}
+                      ariaRowIndex={tableIndex + 2}
+                      title={rowError(row, data.header.length)}
+                    >
+                      <RowHeader
+                        busy={dataIndex === undefined}
+                        style={cornerStyle}
+                        onClick={dataIndex === undefined ? undefined : getOnSelectRowClick({ tableIndex, dataIndex })}
+                        checked={selected}
+                        showCheckBox={showSelection}
+                        ariaColIndex={1}
+                      >{formatRowNumber(dataIndex)}</RowHeader>
+                      {data.header.map((column, columnIndex) => {
                       // Note: the resolved cell value can be undefined
-                      const hasResolved = column in row.cells
-                      const value = row.cells[column]
-                      return <Cell
-                        key={columnIndex}
-                        onDoubleClick={getOnDoubleClickCell(columnIndex, dataIndex)}
-                        onMouseDown={getOnMouseDownCell(columnIndex, dataIndex)}
-                        stringify={stringify}
-                        value={value}
-                        columnIndex={columnIndex}
-                        hasResolved={hasResolved}
-                        className={columnClassNames[columnIndex]}
-                        ariaColIndex={columnIndex + 2} // 1-based index, +1 for the row header
-                      />
-                    })}
-                  </Row>
-                )
-              })}
-              {postPadding.map((_, postPaddingIndex) => {
-                const tableIndex = offset + rowsLength + postPaddingIndex
-                return (
-                  <Row key={tableIndex} ariaRowIndex={tableIndex + 2}>
-                    <RowHeader style={cornerStyle} ariaColIndex={1} />
-                  </Row>
-                )
-              })}
-            </tbody>
-          </table>
+                        const hasResolved = column in row.cells
+                        const value = row.cells[column]
+                        return <Cell
+                          key={columnIndex}
+                          onDoubleClick={getOnDoubleClickCell(columnIndex, dataIndex)}
+                          onMouseDown={getOnMouseDownCell(columnIndex, dataIndex)}
+                          stringify={stringify}
+                          value={value}
+                          columnIndex={columnIndex}
+                          hasResolved={hasResolved}
+                          className={columnClassNames[columnIndex]}
+                          ariaColIndex={columnIndex + 2} // 1-based index, +1 for the row header
+                        />
+                      })}
+                    </Row>
+                  )
+                })}
+                {postPadding.map((_, postPaddingIndex) => {
+                  const tableIndex = offset + rowsLength + postPaddingIndex
+                  return (
+                    <Row key={tableIndex} ariaRowIndex={tableIndex + 2}>
+                      <RowHeader style={cornerStyle} ariaColIndex={1} />
+                    </Row>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
         </div>
+        {/* puts a background behind the row labels column */}
+        <div className={styles.mockRowLabel} style={cornerStyle}>&nbsp;</div>
       </div>
-      {/* puts a background behind the row labels column */}
-      <div className={styles.mockRowLabel} style={cornerStyle}>&nbsp;</div>
-    </div>
+    </FocusProvider>
   </ColumnWidthProvider>
 }

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -238,7 +238,8 @@ export function HighTableInner({
     const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
     if (tableIndex < slice.offset || tableIndex >= slice.offset + slice.rows.length) {
       // scroll to the estimated position of the cell (and wait for the cell to be fetched and rendered)
-      const rowTop = tableIndex * rowHeight
+      // +1 <- to avoid having the cell under the sticky header
+      const rowTop = (tableIndex + 1) * rowHeight
       const scroller = scrollRef.current
       if (scroller) {
         // scroll to the cell

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -113,7 +113,7 @@ export function HighTableInner({
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
-  const { onKeyDown } = useFocus()
+  const { onKeyDown, rowIndex } = useFocus()
 
   // TODO(SL): remove this state and only rely on the data frame for these operations?
   // ie. cache the previous sort indexes in the data frame itself
@@ -228,6 +228,28 @@ export function HighTableInner({
       onSelectionChange({ ranges: [], anchor: undefined })
     }
   }
+
+  // scroll vertically to the focused cell if needed
+  useEffect(() => {
+    if (rowIndex === 1) {
+      // don't scroll if the cell is in the first row or column
+      return
+    }
+    if (!slice) {
+      // don't scroll if the slice is not ready
+      return
+    }
+    const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
+    if (tableIndex < slice.offset || tableIndex >= slice.offset + slice.rows.length) {
+      // scroll to the estimated position of the cell (and wait for the cell to be fetched and rendered)
+      const rowTop = tableIndex * rowHeight
+      const scroller = scrollRef.current
+      if (scroller) {
+        // scroll to the cell
+        scroller.scrollTop = rowTop
+      }
+    }
+  }, [rowIndex, slice])
 
   // handle scrolling and window resizing
   useEffect(() => {

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -238,8 +238,7 @@ export function HighTableInner({
     const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
     if (tableIndex < slice.offset || tableIndex >= slice.offset + slice.rows.length) {
       // scroll to the estimated position of the cell (and wait for the cell to be fetched and rendered)
-      // +1 <- to avoid having the cell under the sticky header
-      const rowTop = (tableIndex + 1) * rowHeight
+      const rowTop = tableIndex * rowHeight
       const scroller = scrollRef.current
       if (scroller) {
         // scroll to the cell

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -114,6 +114,7 @@ export function HighTableInner({
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
   const { onKeyDown, rowIndex } = useFocus()
+  const [lastRowIndex, setLastRowIndex] = useState(rowIndex)
 
   // TODO(SL): remove this state and only rely on the data frame for these operations?
   // ie. cache the previous sort indexes in the data frame itself
@@ -235,6 +236,13 @@ export function HighTableInner({
       // don't scroll if the slice is not ready
       return
     }
+    if (lastRowIndex === rowIndex) {
+      // don't scroll if the row index is unchanged
+      // occurs when the user is scrolling with the mouse for example, and the focused
+      // cell exits the viewport: don't want to scroll back to it
+      return
+    }
+    setLastRowIndex(rowIndex)
     const tableIndex = rowIndex - 2 // 0-based index, -1 for the header
     if (tableIndex < slice.offset || tableIndex >= slice.offset + slice.rows.length) {
       // scroll to the estimated position of the cell (and wait for the cell to be fetched and rendered)
@@ -245,7 +253,7 @@ export function HighTableInner({
         scroller.scrollTop = rowTop
       }
     }
-  }, [rowIndex, slice])
+  }, [rowIndex, slice, lastRowIndex])
 
   // handle scrolling and window resizing
   useEffect(() => {

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties, MouseEvent, ReactNode } from 'react'
+import { CSSProperties, MouseEvent, ReactNode, useRef } from 'react'
+import { useTabIndex } from '../../hooks/useFocus'
 
 interface Props {
   busy?: boolean
@@ -7,14 +8,18 @@ interface Props {
   onClick?: (event: MouseEvent) => void
   showCheckBox?: boolean
   style?: CSSProperties
-  ariaColIndex?: number
-  tabIndex?: number
+  ariaColIndex: number
+  ariaRowIndex: number
 }
 
-export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex, tabIndex }: Props) {
+export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex, ariaRowIndex }: Props) {
+  const ref = useRef<HTMLTableCellElement>(null)
+  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+
   const disabled = !onClick
   return (
     <th
+      ref={ref}
       scope="row"
       role="rowheader"
       style={style}

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, MouseEvent, ReactNode, useCallback, useRef } from 'react'
-import { useCellFocus } from '../../hooks/useFocus'
+import { useCellNavigation } from '../../hooks/useCellsNavigation'
 
 interface Props {
   busy?: boolean
@@ -14,11 +14,11 @@ interface Props {
 
 export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex, ariaRowIndex }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const handleClick = useCallback((event: MouseEvent) => {
-    focusCell()
+    navigateToCell()
     onClick?.(event)
-  }, [onClick, focusCell])
+  }, [onClick, navigateToCell])
 
   const disabled = !onClick
   return (

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -1,5 +1,5 @@
-import { CSSProperties, MouseEvent, ReactNode, useRef } from 'react'
-import { useTabIndex } from '../../hooks/useFocus'
+import { CSSProperties, MouseEvent, ReactNode, useCallback, useRef } from 'react'
+import { useCellFocus } from '../../hooks/useFocus'
 
 interface Props {
   busy?: boolean
@@ -14,7 +14,11 @@ interface Props {
 
 export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex, ariaRowIndex }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const handleClick = useCallback((event: MouseEvent) => {
+    focusCell()
+    onClick?.(event)
+  }, [onClick, focusCell])
 
   const disabled = !onClick
   return (
@@ -23,7 +27,7 @@ export default function RowHeader({ children, checked, onClick, showCheckBox, st
       scope="row"
       role="rowheader"
       style={style}
-      onClick={onClick}
+      onClick={handleClick}
       aria-busy={busy}
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -8,9 +8,10 @@ interface Props {
   showCheckBox?: boolean
   style?: CSSProperties
   ariaColIndex?: number
+  tabIndex?: number
 }
 
-export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex }: Props) {
+export default function RowHeader({ children, checked, onClick, showCheckBox, style, busy, ariaColIndex, tabIndex }: Props) {
   const disabled = !onClick
   return (
     <th
@@ -20,6 +21,7 @@ export default function RowHeader({ children, checked, onClick, showCheckBox, st
       onClick={onClick}
       aria-busy={busy}
       aria-colindex={ariaColIndex}
+      tabIndex={tabIndex}
     >
       <span>{children}</span>
       { showCheckBox && <input type='checkbox' disabled={disabled} checked={checked} readOnly /> }

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, MouseEvent, ReactNode, useCallback, useRef } from 'react'
-import { useCellFocus } from '../../hooks/useFocus'
+import { useCellNavigation } from '../../hooks/useCellsNavigation'
 
 interface Props {
   checked?: boolean
@@ -13,11 +13,11 @@ interface Props {
 
 export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex, ariaRowIndex }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const handleClick = useCallback((event: MouseEvent) => {
-    focusCell()
+    navigateToCell()
     onClick?.(event)
-  }, [onClick, focusCell])
+  }, [onClick, navigateToCell])
 
   return (
     <td

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -1,5 +1,5 @@
-import { CSSProperties, MouseEvent, ReactNode, useRef } from 'react'
-import { useTabIndex } from '../../hooks/useFocus'
+import { CSSProperties, MouseEvent, ReactNode, useCallback, useRef } from 'react'
+import { useCellFocus } from '../../hooks/useFocus'
 
 interface Props {
   checked?: boolean
@@ -13,14 +13,18 @@ interface Props {
 
 export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex, ariaRowIndex }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
-  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+  const { tabIndex, focusCell } = useCellFocus({ ref, ariaColIndex, ariaRowIndex })
+  const handleClick = useCallback((event: MouseEvent) => {
+    focusCell()
+    onClick?.(event)
+  }, [onClick, focusCell])
 
   return (
     <td
       ref={ref}
       aria-disabled={!showCheckBox}
       style={style}
-      onClick={onClick}
+      onClick={handleClick}
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}
     >

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties, MouseEvent, ReactNode } from 'react'
+import { CSSProperties, MouseEvent, ReactNode, useRef } from 'react'
+import { useTabIndex } from '../../hooks/useFocus'
 
 interface Props {
   checked?: boolean
@@ -6,13 +7,23 @@ interface Props {
   onClick?: (event: MouseEvent) => void
   showCheckBox?: boolean
   style?: CSSProperties
-  ariaColIndex?: number
-  tabIndex?: number
+  ariaColIndex: number
+  ariaRowIndex: number
 }
 
-export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex, tabIndex }: Props) {
+export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex, ariaRowIndex }: Props) {
+  const ref = useRef<HTMLTableCellElement>(null)
+  const tabIndex = useTabIndex({ ref, ariaColIndex, ariaRowIndex })
+
   return (
-    <td aria-disabled={!showCheckBox} style={style} onClick={onClick} aria-colindex={ariaColIndex} tabIndex={tabIndex}>
+    <td
+      ref={ref}
+      aria-disabled={!showCheckBox}
+      style={style}
+      onClick={onClick}
+      aria-colindex={ariaColIndex}
+      tabIndex={tabIndex}
+    >
       <span>{children}</span>
       { showCheckBox && <input type='checkbox' checked={checked} readOnly /> }
     </td>

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -7,11 +7,12 @@ interface Props {
   showCheckBox?: boolean
   style?: CSSProperties
   ariaColIndex?: number
+  tabIndex?: number
 }
 
-export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex }: Props) {
+export default function TableCorner({ children, checked, onClick, showCheckBox, style, ariaColIndex, tabIndex }: Props) {
   return (
-    <td aria-disabled={!showCheckBox} style={style} onClick={onClick} aria-colindex={ariaColIndex}>
+    <td aria-disabled={!showCheckBox} style={style} onClick={onClick} aria-colindex={ariaColIndex} tabIndex={tabIndex}>
       <span>{children}</span>
       { showCheckBox && <input type='checkbox' checked={checked} readOnly /> }
     </td>

--- a/src/components/TableHeader/TableHeader.test.tsx
+++ b/src/components/TableHeader/TableHeader.test.tsx
@@ -15,6 +15,7 @@ describe('TableHeader', () => {
       <TableHeader
         dataReady={dataReady}
         header={header}
+        ariaRowIndex={1}
       />
     </tr></thead></table>)
     header.forEach(columnHeader => {
@@ -29,7 +30,9 @@ describe('TableHeader', () => {
         header={header}
         orderBy={[]}
         onOrderByChange={onOrderByChange}
-        dataReady={dataReady} />
+        dataReady={dataReady}
+        ariaRowIndex={1}
+      />
     </tr></thead></table>)
 
     const ageHeader = getByText('Age')
@@ -45,7 +48,9 @@ describe('TableHeader', () => {
         header={header}
         onOrderByChange={onOrderByChange}
         orderBy={[{ column: 'Age', direction: 'ascending' }]}
-        dataReady={dataReady} />
+        dataReady={dataReady}
+        ariaRowIndex={1}
+      />
     </tr></thead></table>)
 
     const ageHeader = getByText('Age')
@@ -61,7 +66,9 @@ describe('TableHeader', () => {
         header={header}
         onOrderByChange={onOrderByChange}
         orderBy={[{ column: 'Age', direction: 'descending' }]}
-        dataReady={dataReady} />
+        dataReady={dataReady}
+        ariaRowIndex={1}
+      />
     </tr></thead></table>)
 
     const ageHeader = getByText('Age')
@@ -77,7 +84,9 @@ describe('TableHeader', () => {
         header={header}
         onOrderByChange={onOrderByChange}
         orderBy={[{ column: 'Age', direction: 'ascending' }]}
-        dataReady={dataReady} />
+        dataReady={dataReady}
+        ariaRowIndex={1}
+      />
     </tr></thead></table>)
 
     const addressHeader = getByText('Address')

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { OrderBy, toggleColumn } from '../../helpers/sort.js'
+import { useTabIndex } from '../../hooks/useFocus.js'
 import ColumnHeader from '../ColumnHeader/ColumnHeader.js'
 
 interface TableProps {
@@ -7,6 +8,7 @@ interface TableProps {
   orderBy?: OrderBy // array of column order by clauses. If undefined, the table is unordered, the sort elements are hidden and the interactions are disabled.
   onOrderByChange?: (orderBy: OrderBy) => void // callback to call when a user interaction changes the order. The interactions are disabled if undefined.
   dataReady: boolean
+  ariaRowIndex: number // aria row index for the header
   sortable?: boolean
   columnClassNames?: (string | undefined)[] // array of class names for each column
 }
@@ -15,8 +17,10 @@ interface TableProps {
  * Render a header for a table.
  */
 export default function TableHeader({
-  header, orderBy, onOrderByChange, dataReady, sortable = true, columnClassNames = [],
+  header, orderBy, onOrderByChange, dataReady, ariaRowIndex, sortable = true, columnClassNames = [],
 }: TableProps) {
+  const getTabIndex = useTabIndex()
+
   // Function to handle click for changing orderBy
   const getOnOrderByClick = useCallback((columnHeader: string) => {
     if (!onOrderByChange || !orderBy) return undefined
@@ -33,6 +37,7 @@ export default function TableHeader({
     // Note: columnIndex is the index of the column in the dataframe header
     // and not the index of the column in the table (which can be different if
     // some columns are hidden, or if the order is changed)
+    const ariaColIndex = columnIndex + 2 // 1-based, include the row header
     return (
       // The ColumnHeader component width is controlled by the parent
       <ColumnHeader
@@ -46,6 +51,8 @@ export default function TableHeader({
         columnName={name}
         columnIndex={columnIndex}
         className={columnClassNames[columnIndex]}
+        tabIndex={getTabIndex({ colIndex: ariaColIndex, rowIndex: ariaRowIndex })}
+        ariaColIndex={ariaColIndex}
       >
         {name}
       </ColumnHeader>

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react'
 import { OrderBy, toggleColumn } from '../../helpers/sort.js'
-import { useTabIndex } from '../../hooks/useFocus.js'
 import ColumnHeader from '../ColumnHeader/ColumnHeader.js'
 
 interface TableProps {
@@ -19,8 +18,6 @@ interface TableProps {
 export default function TableHeader({
   header, orderBy, onOrderByChange, dataReady, ariaRowIndex, sortable = true, columnClassNames = [],
 }: TableProps) {
-  const getTabIndex = useTabIndex()
-
   // Function to handle click for changing orderBy
   const getOnOrderByClick = useCallback((columnHeader: string) => {
     if (!onOrderByChange || !orderBy) return undefined
@@ -51,8 +48,8 @@ export default function TableHeader({
         columnName={name}
         columnIndex={columnIndex}
         className={columnClassNames[columnIndex]}
-        tabIndex={getTabIndex({ colIndex: ariaColIndex, rowIndex: ariaRowIndex })}
         ariaColIndex={ariaColIndex}
+        ariaRowIndex={ariaRowIndex}
       >
         {name}
       </ColumnHeader>

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -70,9 +70,9 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
         setRowIndex(rowCount)
       }
       setColIndex(colCount)
-    } else if (key === 'PageDown') {
+    } else if (key === 'PageDown' || key === ' ' && !event.shiftKey) {
       setRowIndex((prev) => prev + rowPadding <= rowCount ? prev + rowPadding : rowCount )
-    } else if (key === 'PageUp') {
+    } else if (key === 'PageUp' || key === ' ' && event.shiftKey ) {
       setRowIndex((prev) => prev - rowPadding >= 1 ? prev - rowPadding : 1)
     } else {
       // if the key is not one of the above, do not handle it

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -124,6 +124,9 @@ export function useCellNavigation({ ref, ariaColIndex, ariaRowIndex }: CellData)
     // focus on the cell when needed
     if (ref.current && isCurrentCell && document.hasFocus() && document.activeElement !== ref.current && shouldFocus) {
       ref.current.focus()
+      // scroll the cell into view (note scroll-padding-inline-start and scroll-padding-block-start are set in the CSS
+      // to avoid the cell being hidden by the row and column headers)
+      ref.current.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' })
       setShouldFocus?.(false)
     }
   }, [ref, isCurrentCell, ariaColIndex, ariaRowIndex, shouldFocus, setShouldFocus])

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -26,12 +26,11 @@ interface CellsNavigationProviderProps {
 }
 
 export function CellsNavigationProvider({ colCount, rowCount, rowPadding, children }: CellsNavigationProviderProps) {
-  const [colIndex, setColIndex] = useState(1)
-  const [rowIndex, setRowIndex] = useState(1)
+  const [colIndex, setColIndex] = useState(defaultCellsNavigationContext.colIndex)
+  const [rowIndex, setRowIndex] = useState(defaultCellsNavigationContext.rowIndex)
 
   const onKeyDown = useCallback((event: KeyboardEvent) => {
     const { key } = event
-
     if (key === 'ArrowRight') {
       if (event.ctrlKey) {
         setColIndex(colCount)

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -4,22 +4,26 @@ interface CellsNavigationContextType {
   colIndex: number // table column index, same semantic as aria-colindex (1-based, includes row headers)
   rowIndex: number // table row index, same semantic as aria-rowindex (1-based, includes column headers)
   shouldFocus: boolean // true if the current cell should be focused
+  enterCellsNavigation?: boolean // true if entering cells navigation mode
   onTableKeyDown?: (event: KeyboardEvent) => void // function to handle keydown events inside the table. It is created only once.
   onScrollKeyDown?: (event: KeyboardEvent) => void // function to handle keydown events outside the table, in the scroll wrapper. It is created only once.
   setColIndex?: (colIndex: number) => void // function to set the column index
   setRowIndex?: (rowIndex: number) => void // function to set the row index
   setShouldFocus?: (shouldFocus: boolean) => void // function to set the shouldFocus state
+  setEnterCellsNavigation?: (enterCellsNavigation: boolean) => void // function to set the enterCellsNavigation state
 }
 
 const defaultCellsNavigationContext: CellsNavigationContextType = {
   colIndex: 1, // the cursor cell is initially the top-left cell
   rowIndex: 1, //
   shouldFocus: false,
+  enterCellsNavigation: false,
   onTableKeyDown: undefined,
   onScrollKeyDown: undefined,
   setColIndex: undefined,
   setRowIndex: undefined,
   setShouldFocus: undefined,
+  setEnterCellsNavigation: undefined,
 }
 
 export const CellsNavigationContext = createContext<CellsNavigationContextType>(defaultCellsNavigationContext)
@@ -35,6 +39,7 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
   const [colIndex, setColIndex] = useState(defaultCellsNavigationContext.colIndex)
   const [rowIndex, setRowIndex] = useState(defaultCellsNavigationContext.rowIndex)
   const [shouldFocus, setShouldFocus] = useState(false)
+  const [enterCellsNavigation, setEnterCellsNavigation] = useState(false)
 
   const onTableKeyDown = useCallback((event: KeyboardEvent) => {
     const { key } = event
@@ -94,6 +99,7 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
       // avoid scrolling the table when the user is navigating with the keyboard
       event.stopPropagation()
       event.preventDefault()
+      setEnterCellsNavigation(true)
       setShouldFocus(true)
     }
   }, [])
@@ -102,14 +108,17 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
     return {
       colIndex,
       rowIndex,
-      shouldFocus,
       onTableKeyDown,
       onScrollKeyDown,
       setColIndex,
       setRowIndex,
+      shouldFocus,
       setShouldFocus,
+      enterCellsNavigation,
+      setEnterCellsNavigation,
     }
-  }, [colIndex, rowIndex, onTableKeyDown, onScrollKeyDown, shouldFocus])
+  }, [colIndex, rowIndex, onTableKeyDown, onScrollKeyDown, shouldFocus, enterCellsNavigation,
+    setEnterCellsNavigation])
 
   return (
     <CellsNavigationContext.Provider value={value}>

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -123,10 +123,10 @@ export function useCellNavigation({ ref, ariaColIndex, ariaRowIndex }: CellData)
   useEffect(() => {
     // focus on the cell when needed
     if (ref.current && isCurrentCell && document.hasFocus() && document.activeElement !== ref.current && shouldFocus) {
-      ref.current.focus()
       // scroll the cell into view (note scroll-padding-inline-start and scroll-padding-block-start are set in the CSS
       // to avoid the cell being hidden by the row and column headers)
       ref.current.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' })
+      ref.current.focus()
       setShouldFocus?.(false)
     }
   }, [ref, isCurrentCell, ariaColIndex, ariaRowIndex, shouldFocus, setShouldFocus])

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -1,21 +1,70 @@
-import { ReactNode, createContext, useContext } from 'react'
+import { KeyboardEvent, ReactNode, createContext, useCallback, useContext, useMemo, useState } from 'react'
 
-type FocusContextType = 'TODO'
+interface FocusContextType {
+  colIndex: number // table column index, same semantic as aria-colindex (1-based, includes row headers)
+  rowIndex: number // table row index, same semantic as aria-rowindex (1-based, includes column headers)
+  onKeyDown: (event: KeyboardEvent) => void // function to handle keydown events. It is created only once and does not change when the focus changes.
+}
 
-export const FocusContext = createContext<FocusContextType>('TODO')
+const defaultFocusContext: FocusContextType = {
+  colIndex: 1, // the focus is initially on the top-left cell
+  rowIndex: 1, // the focus is initially on the top-left cell
+  onKeyDown: () => {
+    // no-op
+  },
+}
+
+export const FocusContext = createContext<FocusContextType>(defaultFocusContext)
 
 interface FocusProviderProps {
+  colCount: number // number of columns in the table, same semantic as aria-colcount (includes row headers)
+  rowCount: number // number of rows in the table, same semantic as aria-rowcount (includes column headers)
   children: ReactNode
 }
 
-export function FocusProvider({ children }: FocusProviderProps) {
+export function FocusProvider({ colCount, rowCount, children }: FocusProviderProps) {
+  const [colIndex, setColIndex] = useState(1)
+  const [rowIndex, setRowIndex] = useState(1)
+
+  const onKeyDown = useCallback((event: KeyboardEvent) => {
+    const { key } = event
+    if (key === 'ArrowRight') {
+      setColIndex((prev) => prev < colCount ? prev + 1 : prev)
+    } else if (key === 'ArrowLeft') {
+      setColIndex((prev) => prev > 1 ? prev - 1 : prev)
+    } else if (key === 'ArrowDown') {
+      setRowIndex((prev) => prev < rowCount ? prev + 1 : prev)
+    } else if (key === 'ArrowUp') {
+      setRowIndex((prev) => prev > 1 ? prev - 1 : prev)
+    }
+  }, [colCount, rowCount])
+
+  const value = useMemo(() => {
+    return {
+      colIndex,
+      rowIndex,
+      onKeyDown,
+    }
+  }, [colIndex, rowIndex, onKeyDown])
+
   return (
-    <FocusContext.Provider value={'TODO'}>
+    <FocusContext.Provider value={value}>
       {children}
     </FocusContext.Provider>
   )
 }
 
-export default function useFocus() {
-  return useContext(FocusContext)
+interface CellPosition {
+  colIndex: number // table column index, same semantic as aria-colindex (1-based, includes row headers)
+  rowIndex: number // table row index, same semantic as aria-rowindex (1-based, includes column headers)
+}
+type TabIndex = -1 | 0 // -1 if the cell is not focused, 0 if it is focused
+
+export function useTabIndex(): ({ colIndex, rowIndex }: CellPosition) => TabIndex {
+  const focus = useContext(FocusContext)
+  return useCallback(({ colIndex, rowIndex }: CellPosition): TabIndex => {
+    // Check if the cell is focused
+    const isFocused = colIndex === focus.colIndex && rowIndex === focus.rowIndex
+    return isFocused ? 0 : -1 // -1 if the cell is not focused, 0 if it is focused
+  }, [focus.rowIndex, focus.colIndex])
 }

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -30,9 +30,6 @@ export function FocusProvider({ colCount, rowCount, rowPadding, children }: Focu
   const [rowIndex, setRowIndex] = useState(1)
 
   const onKeyDown = useCallback((event: KeyboardEvent) => {
-    // avoid scrolling the table when the user is navigating with the keyboard
-    event.stopPropagation()
-    event.preventDefault()
     const { key } = event
 
     if (key === 'ArrowRight') {
@@ -73,7 +70,13 @@ export function FocusProvider({ colCount, rowCount, rowPadding, children }: Focu
       setRowIndex((prev) => prev + rowPadding <= rowCount ? prev + rowPadding : rowCount )
     } else if (key === 'PageUp') {
       setRowIndex((prev) => prev - rowPadding >= 1 ? prev - rowPadding : 1)
+    } else {
+      // if the key is not one of the above, do not handle it
+      return
     }
+    // avoid scrolling the table when the user is navigating with the keyboard
+    event.stopPropagation()
+    event.preventDefault()
   }, [colCount, rowCount, rowPadding])
 
   const value = useMemo(() => {

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -35,14 +35,25 @@ export function FocusProvider({ colCount, rowCount, children }: FocusProviderPro
     const { key } = event
 
     if (key === 'ArrowRight') {
-      setColIndex((prev) => prev < colCount ? prev + 1 : prev)
+      if (event.ctrlKey) {
+        setColIndex(colCount)
+      } else {
+        setColIndex((prev) => prev < colCount ? prev + 1 : prev)
+      }
     } else if (key === 'ArrowLeft') {
-      setColIndex((prev) => prev > 1 ? prev - 1 : prev)
+      if (event.ctrlKey) {
+        setColIndex(1)
+      } else {
+        setColIndex((prev) => prev > 1 ? prev - 1 : prev)
+      }
     } else if (key === 'ArrowDown') {
       setRowIndex((prev) => prev < rowCount ? prev + 1 : prev)
     } else if (key === 'ArrowUp') {
       setRowIndex((prev) => prev > 1 ? prev - 1 : prev)
     } else if (key === 'Home') {
+      if (event.ctrlKey) {
+        setRowIndex(1)
+      }
       setColIndex(1)
     } else if (key === 'End') {
       setColIndex(colCount)

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -57,6 +57,9 @@ export function FocusProvider({ colCount, rowCount, rowPadding, children }: Focu
       }
       setColIndex(1)
     } else if (key === 'End') {
+      if (event.ctrlKey) {
+        setRowIndex(rowCount)
+      }
       setColIndex(colCount)
     } else if (key === 'PageDown') {
       setRowIndex((prev) => prev + rowPadding <= rowCount ? prev + rowPadding : rowCount )

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -107,8 +107,6 @@ interface CellFocus {
 export function useCellFocus({ ref, ariaColIndex, ariaRowIndex }: CellData): CellFocus {
   const { colIndex, rowIndex, setColIndex, setRowIndex } = useContext(FocusContext)
 
-  const cell = ariaColIndex === 1 && ariaRowIndex === 1
-
   // Check if the cell is focused
   const isFocused = ariaColIndex === colIndex && ariaRowIndex === rowIndex
 
@@ -117,7 +115,7 @@ export function useCellFocus({ ref, ariaColIndex, ariaRowIndex }: CellData): Cel
     if (ref.current && isFocused && document.activeElement !== ref.current) {
       ref.current.focus()
     }
-  }, [ref, isFocused, ariaColIndex, ariaRowIndex, cell])
+  }, [ref, isFocused, ariaColIndex, ariaRowIndex])
 
   const tabIndex = isFocused ? 0 : -1 // -1 if the cell is not focused, 0 if it is focused
 

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -21,10 +21,11 @@ export const FocusContext = createContext<FocusContextType>(defaultFocusContext)
 interface FocusProviderProps {
   colCount: number // number of columns in the table, same semantic as aria-colcount (includes row headers)
   rowCount: number // number of rows in the table, same semantic as aria-rowcount (includes column headers)
+  rowPadding: number // number of rows to skip when navigating with the keyboard
   children: ReactNode
 }
 
-export function FocusProvider({ colCount, rowCount, children }: FocusProviderProps) {
+export function FocusProvider({ colCount, rowCount, rowPadding, children }: FocusProviderProps) {
   const [colIndex, setColIndex] = useState(1)
   const [rowIndex, setRowIndex] = useState(1)
 
@@ -57,8 +58,12 @@ export function FocusProvider({ colCount, rowCount, children }: FocusProviderPro
       setColIndex(1)
     } else if (key === 'End') {
       setColIndex(colCount)
+    } else if (key === 'PageDown') {
+      setRowIndex((prev) => prev + rowPadding <= rowCount ? prev + rowPadding : rowCount )
+    } else if (key === 'PageUp') {
+      setRowIndex((prev) => prev - rowPadding >= 1 ? prev - rowPadding : 1)
     }
-  }, [colCount, rowCount])
+  }, [colCount, rowCount, rowPadding])
 
   const value = useMemo(() => {
     return {

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -48,9 +48,17 @@ export function FocusProvider({ colCount, rowCount, rowPadding, children }: Focu
         setColIndex((prev) => prev > 1 ? prev - 1 : prev)
       }
     } else if (key === 'ArrowDown') {
-      setRowIndex((prev) => prev < rowCount ? prev + 1 : prev)
+      if (event.ctrlKey) {
+        setRowIndex(rowCount)
+      } else {
+        setRowIndex((prev) => prev < rowCount ? prev + 1 : prev)
+      }
     } else if (key === 'ArrowUp') {
-      setRowIndex((prev) => prev > 1 ? prev - 1 : prev)
+      if (event.ctrlKey) {
+        setRowIndex(1)
+      } else {
+        setRowIndex((prev) => prev > 1 ? prev - 1 : prev)
+      }
     } else if (key === 'Home') {
       if (event.ctrlKey) {
         setRowIndex(1)

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -42,6 +42,10 @@ export function FocusProvider({ colCount, rowCount, children }: FocusProviderPro
       setRowIndex((prev) => prev < rowCount ? prev + 1 : prev)
     } else if (key === 'ArrowUp') {
       setRowIndex((prev) => prev > 1 ? prev - 1 : prev)
+    } else if (key === 'Home') {
+      setColIndex(1)
+    } else if (key === 'End') {
+      setColIndex(colCount)
     }
   }, [colCount, rowCount])
 

--- a/src/hooks/useFocus.tsx
+++ b/src/hooks/useFocus.tsx
@@ -1,0 +1,21 @@
+import { ReactNode, createContext, useContext } from 'react'
+
+type FocusContextType = 'TODO'
+
+export const FocusContext = createContext<FocusContextType>('TODO')
+
+interface FocusProviderProps {
+  children: ReactNode
+}
+
+export function FocusProvider({ children }: FocusProviderProps) {
+  return (
+    <FocusContext.Provider value={'TODO'}>
+      {children}
+    </FocusContext.Provider>
+  )
+}
+
+export default function useFocus() {
+  return useContext(FocusContext)
+}


### PR DESCRIPTION
Needed for #30

This PR adds the keyboard event handlers to navigate the table cells as expected. The actions in each cell will be implemented other PRs

The list of expected keyboard interactions are published in https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role#keyboard_interactions or https://www.w3.org/WAI/ARIA/apg/patterns/grid/#datagridsforpresentingtabularinformation

- [x] Right Arrow: Moves focus one cell to the right. If focus is on the right-most cell in the row, focus does not move.
- [x] Left Arrow: Moves focus one cell to the left. If focus is on the left-most cell in the row, focus does not move.
- [x] Down Arrow: Moves focus one cell down. If focus is on the bottom cell in the column, focus does not move.
- [x] Up Arrow: Moves focus one cell up. If focus is on the top cell in the column, focus does not move.
- [x] Page Down: Moves focus down an author-determined number of rows, typically scrolling so the bottom row in the currently visible set of rows becomes one of the first visible rows. If focus is in the last row of the grid, focus does not move.
- [x] Page Up: Moves focus up an author-determined number of rows, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.
- [x] Home: moves focus to the first cell in the row that contains focus.
- [x] End: moves focus to the last cell in the row that contains focus.
- [x] Control + Home: moves focus to the first cell in the first row.
- [x] Control + End: moves focus to the last cell in the last row.

We must choose one of two options for handling the focus inside the table: "Roving tabindex" vs "aria-activedescendant". See https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#keyboardnavigationinsidecomponents.

We'll try "roving tabindex". The focus will be in one of the cells with `tabindex="0"`, and the other ones will have `tabindex="-1"` so that they can be selected with `.focus()` but are no part of the Tab path. An interesting implementation here: https://github.com/stevejay/react-roving-tabindex/blob/master/src/use-roving-tabindex.ts

---

Some problems appeared:

- [x] when scrolling with the mouse, or after switching back to the scroll div with Tab and scrolling with arrows, the useEffect snippet scrolls back to the currently focused cell. We want to keep the reference of the highlighted cell and show it as such, but we don't want to scroll back to it when we're not in that mode - fixed with https://github.com/hyparam/hightable/pull/140/commits/376fe09eda1864dd5821582d0ba674e6a6c53205. See the next point though
- [x] after fixing the previous point: when scrolling too much (or pressing PgDown for a long time), the focused cell is not part of the table anymore (it's a virtual table), and the focus is moved to the page `<body>`. In that case, you can't use the arrows keys anymore, while we would expect going back to the focused cell. Maybe we should separate the concepts of focused cell and selected/current cell. Fixed with https://github.com/hyparam/hightable/pull/140/commits/93369e6da12359562b26892de1d638344f5709fa
- [x] another issue with scrolling, related to the previous point (switching the focus between the cell and the body): when scrolling back near to the cell, so that it is rendered again, the scroll jumps up to the cell, which is not expected (we only want to style the current cell, but not focus it while we're scrolling) - fixed with https://github.com/hyparam/hightable/pull/140/commits/93369e6da12359562b26892de1d638344f5709fa:

https://github.com/user-attachments/assets/1b7884ce-2f59-4f68-8f06-532f1053f255


  Should we consider implementing `aria-activedescendant` instead of tabindex roving, and let the table focused? From https://sarahmhigley.com/writing/activedescendant/, it seems like it's not a good idea.
- [x] when navigating quickly with PageUp/PageDown (keeping them pressed for example), we can get to the point where the selected cell is invisible, because it's under the sticky header. Same when navigating upwards (see video). In that case, we would want to scroll down one or two rows to see the cell. Fixed with https://github.com/hyparam/hightable/pull/140/commits/1f11ab5ef3a67e93ac3567ec3ed71d47bb72f882

https://github.com/user-attachments/assets/323d9e1e-07bc-467e-8fa9-4b39ccf6848a


- [x] clicking the column resize separator focuses the header cell, but it's not preserved in the focus context, and moving with the arrows returns to the previously focused cell. Maybe set `tabindex="0"` on the resize separator as well when navigating to a column header cell, so that it's selectable with Tab, and then left and right arrow could be used to resize. It would fix the next point. Done with https://github.com/hyparam/hightable/pull/140/commits/b3844551afe3eb56bf49851db54a09e65eadc546
- [x] it's not possible to select and operate the column resize separator with the keyboard. Done with https://github.com/hyparam/hightable/pull/140/commits/b05db423fd5bbf8edb9a1f1e7c40fab06c479613
- [x] the horizontal scroll is unstable when resizing a column using the keyboard - fixed with https://github.com/hyparam/hightable/pull/140/commits/2a2a1cd9801fbdc21fd00fb1ec5ee5eadb056d85

https://github.com/user-attachments/assets/0d846754-f9a1-4dc6-b216-eaced696d4b2

- [x] navigating to the right/left with the keyboard should scroll to show the current cell as a whole (aligning with the left side if the cell is larger than the scroll area) - fixed with https://github.com/hyparam/hightable/pull/140/commits/a027aa4d0cf41a303d78ce52c4ae1565a13abea6

https://github.com/user-attachments/assets/b250ad31-3206-4410-a926-7339d49f2f09

- [x] fix failing test: https://github.com/hyparam/hightable/pull/140/commits/7952c9b18ad3efbc2fd0bbe5e85a6d8b54aa07aa, https://github.com/hyparam/hightable/pull/140/commits/64b892df6a03e5c00b2b050d9b1cd7eede902451
- [x] pressing space scrolls down by half a page, and after pressing it multiple times, the current cell disappears and cannot be focused again. Same with Shift + space to scroll up. Fixed with https://github.com/hyparam/hightable/pull/140/commits/27931619785b91d00fd8778eff7d1a69a6ed685d
- [x] when focusing a cell, then pressing Shift+Tab to focus the table scroll, then scrolling until the current cell is deleted from the virtual table, then pressing Tab -> no focus. We should fetch the slice with the current cell, and focus it. Fixed with https://github.com/hyparam/hightable/pull/140/commits/feb1ef9f074ed7cacc3b6ed9d3ed3d8287626758

Missing:

- [x] add tests
