### PR TITLE
Faster resolvablePromise by skipping wrapPromise

### DIFF
--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -39,13 +39,17 @@ export function wrapResolved<T>(value: T): WrappedPromise<T> {
 export function resolvablePromise<T>(): ResolvablePromise<T> {
   let resolve: (value: T) => void
   let reject: (reason?: any) => void
-  const promise = wrapPromise(new Promise<T>((res, rej) => {
+  const promise = new Promise<T>((res, rej) => {
     resolve = res
     reject = rej
-  })) as ResolvablePromise<T>
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  promise.resolve = resolve!
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  promise.reject = reject!
+  }) as ResolvablePromise<T> & WrappedPromise<T>
+  promise.resolve = result => {
+    promise.resolved = result
+    resolve(result)
+  }
+  promise.reject = error => {
+    promise.rejected = error
+    reject(error)
+  }
   return promise
 }


### PR DESCRIPTION
Making `resolvableRows` was slowwww if there are a lot of cells. (thanks @bleakley for reporting)

I did some investigation. Runtime increases proportional to the number of cells made (`rows x columns`).

Creating `resolvablePromise` for each cell is relatively expensive. It creates multiple function contexts, and breaks the type hierarchy in a way that the JS runtime probably _hates_.

I made things better by skipping the call to `wrapPromise` and constructing our own resolvable + wrapped promise in one shot. While this is not a total solution to performance issues, this is an improvement of **over 30%** on a common operation.

## Benchmark

```js
const startTime = performance.now()

const numRows = 100_000
const header = ['id', 'name', 'age', 'city']
asyncRows(Promise.resolve([]), numRows, header)

console.log('made async rows in', performance.now() - startTime)
```

| branch | runtime (ms) |
| - | - |
| master | 579ms +/- 81ms | 
| faster-resolvablePromise | 388ms +/- 38ms |
