### PR TITLE
remove ability to navigate with Space/Shift+Space

### DIFF
--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -719,9 +719,9 @@ describe('Navigating Hightable with the keyboard', () => {
       ['{ArrowDown}', rowIndex + 1, colIndex],
       // ['{Control>}{ArrowDown}{/Control}', lastRow, 3], // Cannot be tested because it relies on scroll
       ['{PageUp}', rowIndex - pageSize, colIndex],
-      ['{Shift>}{ }{/Shift}', rowIndex - pageSize, colIndex],
+      ['{Shift>}{ }{/Shift}', rowIndex, colIndex], // no op
       ['{PageDown}', rowIndex + pageSize, colIndex],
-      ['{ }', rowIndex + pageSize, colIndex],
+      ['{ }', rowIndex, colIndex], // no op
       ['{Home}', rowIndex, firstCol],
       ['{Control>}{Home}{/Control}', firstRow, firstCol],
       ['{End}', rowIndex, lastCol],

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -78,9 +78,9 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
         setRowIndex(rowCount)
       }
       setColIndex(colCount)
-    } else if (key === 'PageDown' || key === ' ' && !event.shiftKey) {
+    } else if (key === 'PageDown') {
       setRowIndex((prev) => prev + rowPadding <= rowCount ? prev + rowPadding : rowCount )
-    } else if (key === 'PageUp' || key === ' ' && event.shiftKey ) {
+    } else if (key === 'PageUp') {
       setRowIndex((prev) => prev - rowPadding >= 1 ? prev - rowPadding : 1)
     } else {
       // if the key is not one of the above, do not handle it

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -82,8 +82,10 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
       setRowIndex((prev) => prev + rowPadding <= rowCount ? prev + rowPadding : rowCount )
     } else if (key === 'PageUp') {
       setRowIndex((prev) => prev - rowPadding >= 1 ? prev - rowPadding : 1)
-    } else {
+    } else if (key !== ' ') {
       // if the key is not one of the above, do not handle it
+      // special case: no action is associated with the Space key, but it's captured
+      // anyway to prevent the default action (scrolling the page) and stay in navigation mode
       return
     }
     // avoid scrolling the table when the user is navigating with the keyboard


### PR DESCRIPTION
Breaking: remove the ability to navigate with Space/Shift+Space

we need Shift+Space for row selection, see https://github.com/hyparam/hightable/issues/30#issuecomment-2890508732