### PR TITLE
[refactor] Move data to context and pass key

### DIFF
--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -497,7 +497,7 @@ describe('in uncontrolled selection state (onSelection prop), ', () => {
     expect(queryByRole('row', { selected: true })?.getAttribute('aria-rowindex')).toBe(`${start + 2}`)
   })
 
-  it('on data change, onSelection is called with an empty selection and the DOM is updated to unselect the rows', async () => {
+  it('on data change, the DOM is updated to unselect the rows', async () => {
     const start = 2
     const onSelectionChange = vi.fn()
     const { user, rerender, findByRole, queryByRole } = render(<HighTable data={data} onSelectionChange={onSelectionChange}/>)
@@ -520,7 +520,9 @@ describe('in uncontrolled selection state (onSelection prop), ', () => {
     await findByRole('cell', { name: 'other 2' })
     expect(queryByRole('cell', { name: 'row 2' })).toBeNull()
     expect(queryByRole('row', { selected: true })).toBeNull()
-    expect(onSelectionChange).toHaveBeenCalledWith({ ranges: [] })
+    onSelectionChange.mockClear()
+    // all the internal state is reset when the data changes, and onSelectionChange is not called on initialization
+    expect(onSelectionChange).not.toHaveBeenCalled()
   })
 
   it('passing the selection prop is ignored and a warning is printed in the console', async () => {

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -144,7 +144,7 @@ export function HighTableInner({
   // Sorting is disabled if the data is not sortable
   const { orderBy, onOrderByChange } = useOrderBy()
 
-  const { selection, onSelectionChange, resetSelection } = useSelection()
+  const { selection, onSelectionChange } = useSelection()
 
   const showSelection = selection !== undefined
   const showSelectionControls = showSelection && onSelectionChange !== undefined

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -6,6 +6,7 @@ import { OrderBy, areEqualOrderBy } from '../../helpers/sort.js'
 import { leftCellStyle } from '../../helpers/width.js'
 import { CellsNavigationProvider, useCellsNavigation } from '../../hooks/useCellsNavigation.js'
 import { ColumnWidthProvider } from '../../hooks/useColumnWidth.js'
+import { DataProvider, useData } from '../../hooks/useData.js'
 import { OrderByProvider, useOrderBy } from '../../hooks/useOrderBy.js'
 import { SelectionProvider, useSelection } from '../../hooks/useSelection.js'
 import { stringify as stringifyDefault } from '../../utils/stringify.js'
@@ -63,11 +64,22 @@ const ariaOffset = 2 // 1-based index, +1 for the header
  * onSelectionChange: the callback to call when the selection changes. If undefined, the component selection is read-only if controlled (selection is set), or disabled if not.
  */
 export default function HighTable(props: Props) {
-  const { data, cacheKey, orderBy, onOrderByChange, selection, onSelectionChange } = props
+  return (
+    <DataProvider data={props.data}>
+      <HighTableData {...props} />
+    </DataProvider>
+  )
+}
+
+type PropsData = Omit<Props, 'data'>
+
+function HighTableData(props: PropsData) {
+  const { data, key } = useData()
+  const { cacheKey, orderBy, onOrderByChange, selection, onSelectionChange } = props
   const ariaColCount = data.header.length + 1 // don't forget the selection column
   const ariaRowCount = data.numRows + 1 // don't forget the header row
   return (
-    <OrderByProvider orderBy={orderBy} onOrderByChange={onOrderByChange} disabled={!data.sortable}>
+    <OrderByProvider key={key} orderBy={orderBy} onOrderByChange={onOrderByChange} disabled={!data.sortable}>
       <SelectionProvider selection={selection} onSelectionChange={onSelectionChange}>
         <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
           <CellsNavigationProvider colCount={ariaColCount} rowCount={ariaRowCount} rowPadding={props.padding ?? defaultPadding}>
@@ -80,7 +92,7 @@ export default function HighTable(props: Props) {
   )
 }
 
-type PropsInner = Omit<Props, 'orderBy' | 'onOrderByChange' | 'selection' | 'onSelectionChange'>
+type PropsInner = Omit<PropsData, 'orderBy' | 'onOrderByChange' | 'selection' | 'onSelectionChange'>
 
 /**
  * The main purpose of extracting HighTableInner from HighTable is to
@@ -88,7 +100,6 @@ type PropsInner = Omit<Props, 'orderBy' | 'onOrderByChange' | 'selection' | 'onS
  * remove the need to reindent the code if adding a new context provide.
  */
 export function HighTableInner({
-  data,
   overscan = defaultOverscan,
   padding = defaultPadding,
   focus = true,
@@ -118,6 +129,7 @@ export function HighTableInner({
    * - data.rows(tableIndex, tableIndex + 1, orderBy)
    */
 
+  const { data } = useData()
   const [slice, setSlice] = useState<Slice | undefined>(undefined)
   const [rowsRange, setRowsRange] = useState({ start: 0, end: 0 })
   const [hasCompleteRow, setHasCompleteRow] = useState(false)
@@ -202,23 +214,6 @@ export function HighTableInner({
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const pendingRequest = useRef(0)
-
-  // invalidate when data changes so that columns will auto-resize
-  useEffect(() => {
-    if (!slice || data === slice.data) {
-      return
-    }
-    // delete the slice
-    setSlice(undefined)
-    // reset the flag, the column widths will be recalculated
-    setHasCompleteRow(false)
-    // delete the cached sort indexes
-    setRanksMap(new Map())
-    // if uncontrolled, reset the selection (if controlled, it's the responsibility of the parent to do it)
-    resetSelection?.()
-    // reset the number of rows
-    setNumRows(data.numRows)
-  }, [data, slice, resetSelection])
 
   // scroll vertically to the focused cell if needed
   useEffect(() => {

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -204,7 +204,10 @@ export function HighTableInner({
   const pendingRequest = useRef(0)
 
   // invalidate when data changes so that columns will auto-resize
-  if (slice && data !== slice.data) {
+  useEffect(() => {
+    if (!slice || data === slice.data) {
+      return
+    }
     // delete the slice
     setSlice(undefined)
     // reset the flag, the column widths will be recalculated
@@ -215,7 +218,7 @@ export function HighTableInner({
     resetSelection?.()
     // reset the number of rows
     setNumRows(data.numRows)
-  }
+  }, [data, slice, resetSelection])
 
   // scroll vertically to the focused cell if needed
   useEffect(() => {

--- a/src/hooks/useData.tsx
+++ b/src/hooks/useData.tsx
@@ -1,0 +1,53 @@
+import { ReactNode, createContext, useContext, useState } from 'react'
+import { DataFrame } from '../helpers/dataframe.js'
+
+interface DataContextType {
+  data: DataFrame,
+  key: string,
+}
+
+function getDefaultDataContext(): DataContextType {
+  return {
+    data: {
+      numRows: 0,
+      header: [],
+      rows: () => [],
+    },
+    key: 'default',
+  }
+}
+
+export const DataContext = createContext<DataContextType>(getDefaultDataContext())
+
+interface DataProviderProps {
+  data: DataFrame,
+  children: ReactNode
+}
+
+function getRandomKey(): string {
+  return crypto.randomUUID()
+}
+
+export function DataProvider({ children, data }: DataProviderProps) {
+  // We want a string key to identify the data.
+  const [key, setKey] = useState<string>(getRandomKey())
+  const [previousData, setPreviousData] = useState<DataFrame>(data)
+
+  if (data !== previousData) {
+    setKey(getRandomKey())
+    setPreviousData(data)
+  }
+
+  return (
+    <DataContext.Provider value={{
+      data,
+      key,
+    }}>
+      {children}
+    </DataContext.Provider>
+  )
+}
+
+export function useData() {
+  return useContext(DataContext)
+}

--- a/src/hooks/useSelection.tsx
+++ b/src/hooks/useSelection.tsx
@@ -5,7 +5,6 @@ import { useInputState } from './useInputState.js'
 interface SelectionContextType {
   selection?: Selection // selection and anchor rows, expressed as data indexes (not as indexes in the table). If undefined, the selection is hidden and the interactions are disabled.
   onSelectionChange?: (selection: Selection) => void // callback to call when a user interaction changes the selection. The selection is expressed as data indexes (not as indexes in the table). The interactions are disabled if undefined.
-  resetSelection?: () => void
 }
 
 export const SelectionContext = createContext<SelectionContextType>({})
@@ -28,7 +27,6 @@ export function SelectionProvider({ children, selection, onSelectionChange }: Se
     <SelectionContext.Provider value={{
       selection: state.value,
       onSelectionChange: state.onChange,
-      resetSelection: () => state.resetTo?.(getDefaultSelection()),
     }}>
       {children}
     </SelectionContext.Provider>


### PR DESCRIPTION
This way, the flow is unidirectional, and we don't need a useEffect to reset everything if data changes.