### PR TITLE
[refactor] Add aria rowindex to cells

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -66,6 +66,7 @@ export default function Cell({ onDoubleClick, onMouseDown, onKeyDown, stringify,
       ref={ref}
       role="cell"
       aria-busy={!hasResolved}
+      aria-rowindex={ariaRowIndex}
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}
       onDoubleClick={handleDoubleClick}

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -100,6 +100,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       data-order-by-size={orderBySize}
       aria-label={columnName}
       aria-description={description}
+      aria-rowindex={ariaRowIndex}
       aria-colindex={ariaColIndex}
       tabIndex={tabIndex}
       title={description}

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -767,7 +767,7 @@ describe('Navigating Hightable with the keyboard', () => {
       render(<HighTable data={data} />)
       const focusedElement = document.activeElement
       expect(focusedElement?.getAttribute('aria-colindex')).toBe('1')
-      expect(focusedElement?.closest('[role="row"]')?.getAttribute('aria-rowindex')).toBe('1')
+      expect(focusedElement?.getAttribute('aria-rowindex')).toBe('1')
     })
     it('the first cell is not focused if focus prop is false, and neither is the table scroller', () => {
       render(<HighTable data={data} focus={false} />)
@@ -788,7 +788,7 @@ describe('Navigating Hightable with the keyboard', () => {
       await user.keyboard(key)
       const focusedElement = document.activeElement
       expect(focusedElement?.getAttribute('aria-colindex')).toBe('1')
-      expect(focusedElement?.closest('[role="row"]')?.getAttribute('aria-rowindex')).toBe('1')
+      expect(focusedElement?.getAttribute('aria-rowindex')).toBe('1')
     })
     it.for(['{Shift>}{Tab}{/Shift}'])('moves the focus outside of the table when pressing "%s"', async (key) => {
       const { user } = render(<HighTable data={data} />)
@@ -821,7 +821,7 @@ describe('Navigating Hightable with the keyboard', () => {
 
   function getFocusCoordinates() {
     const focusedElement = document.activeElement
-    const rowIndex = focusedElement?.closest('[role="row"]')?.getAttribute('aria-rowindex')
+    const rowIndex = focusedElement?.getAttribute('aria-rowindex')
     const colIndex = focusedElement?.getAttribute('aria-colindex')
     expect(rowIndex).toBeDefined()
     expect(colIndex).toBeDefined()

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -38,6 +38,7 @@ export default function RowHeader({ children, checked, onCheckboxPress, style, b
       onKeyDown={handleKeyDown}
       aria-busy={busy}
       aria-checked={checked}
+      aria-rowindex={ariaRowIndex}
       aria-colindex={ariaColIndex}
       aria-disabled={onCheckboxPress === undefined}
       tabIndex={tabIndex}

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -33,6 +33,7 @@ export default function TableCorner({ children, checked, onCheckboxPress, style,
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       aria-checked={checked}
+      aria-rowindex={ariaRowIndex}
       aria-colindex={ariaColIndex}
       aria-disabled={onCheckboxPress === undefined}
       tabIndex={tabIndex}


### PR DESCRIPTION
We already set `aria-rowindex` on the rows (`<tr>` elements). Here we also set it to the inner cells, for convenience. The spec tells us it's allowed and optional.