### PR TITLE
enable (=color) the checkboxes when actionable, but don't let them being focused

### DIFF
--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -485,7 +485,7 @@ export function HighTableInner({
                 const tableIndex = slice.offset + sliceIndex
                 const inferredDataIndex = orderBy === undefined || orderBy.length === 0 ? tableIndex : undefined
                 const dataIndex = row.index ?? inferredDataIndex
-                const selected = isRowSelected(dataIndex) ?? false
+                const selected = isRowSelected(dataIndex)
                 const ariaRowIndex = tableIndex + ariaOffset
                 return (
                   <Row

--- a/src/components/RowHeader/RowHeader.tsx
+++ b/src/components/RowHeader/RowHeader.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, KeyboardEvent, MouseEvent, ReactNode, useCallback, useRef } from 'react'
+import { CSSProperties, ChangeEvent, KeyboardEvent, MouseEvent, ReactNode, useCallback, useRef } from 'react'
 import { useCellNavigation } from '../../hooks/useCellsNavigation'
 
 interface Props {
@@ -28,6 +28,9 @@ export default function RowHeader({ children, checked, onCheckboxPress, style, b
       onCheckboxPress?.(event.shiftKey)
     }
   }, [onCheckboxPress])
+  const showCheckBox = checked !== undefined
+  const disabledCheckbox = onCheckboxPress === undefined
+  const onChange = useCallback((e: ChangeEvent) => {e.preventDefault()}, [])
 
   return (
     <th
@@ -41,15 +44,20 @@ export default function RowHeader({ children, checked, onCheckboxPress, style, b
       aria-checked={checked}
       aria-rowindex={ariaRowIndex}
       aria-colindex={ariaColIndex}
-      aria-disabled={onCheckboxPress === undefined}
+      aria-disabled={disabledCheckbox}
       tabIndex={tabIndex}
       data-rowindex={dataRowIndex}
     >
       <span>{children}</span>
-      {
-        // TODO: use an icon instead of a checkbox
-        checked !== undefined && <input type='checkbox' disabled={true} checked={checked} role="presentation" />
-      }
+      {showCheckBox && <input
+        type='checkbox'
+        onChange={onChange}
+        readOnly={disabledCheckbox}
+        disabled={disabledCheckbox}
+        checked={checked}
+        role="presentation"
+        tabIndex={-1}
+      />}
     </th>
   )
 }

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, KeyboardEvent, ReactNode, useCallback, useRef } from 'react'
+import { CSSProperties, ChangeEvent, KeyboardEvent, ReactNode, useCallback, useRef } from 'react'
 import { useCellNavigation } from '../../hooks/useCellsNavigation'
 
 interface Props {
@@ -25,6 +25,9 @@ export default function TableCorner({ children, checked, onCheckboxPress, style,
       onCheckboxPress?.()
     }
   }, [onCheckboxPress])
+  const showCheckBox = checked !== undefined
+  const disabledCheckbox = onCheckboxPress === undefined
+  const onChange = useCallback((e: ChangeEvent) => {e.preventDefault()}, [])
 
   return (
     <td
@@ -35,13 +38,22 @@ export default function TableCorner({ children, checked, onCheckboxPress, style,
       aria-checked={checked}
       aria-rowindex={ariaRowIndex}
       aria-colindex={ariaColIndex}
-      aria-disabled={onCheckboxPress === undefined}
+      aria-disabled={disabledCheckbox}
       tabIndex={tabIndex}
     >
-      <span>{children}</span>
       {
-        // TODO: use an icon instead of a checkbox
-        checked !== undefined && <input type='checkbox' disabled={true} checked={checked} role="presentation" />
+        showCheckBox ?
+          <input
+            type='checkbox'
+            onChange={onChange}
+            readOnly={disabledCheckbox}
+            disabled={disabledCheckbox}
+            checked={checked}
+            role="presentation"
+            tabIndex={-1}
+          />
+          :
+          <span>{children}</span>
       }
     </td>
   )


### PR DESCRIPTION
Fixes #188 (the real issue being the lack of differentiation between active and readonly)

Before



https://github.com/user-attachments/assets/3816a4b5-b764-461a-a5e0-1d124d542615



After


https://github.com/user-attachments/assets/4aca92ff-0361-452e-9022-f9a65ed2e4d2

Note that we still have the issue (or maybe it's only a detail) that the checkboxes are rendered differently depending on the browser.
