### PR TITLE
Switch to box-sizing: border-box

### DIFF
--- a/src/components/ColumnHeader/ColumnHeader.test.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.test.tsx
@@ -70,7 +70,7 @@ describe('ColumnHeader', () => {
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
   })
 
-  it('handles double click to auto resize', async () => {
+  it('handles double click on resize handle to auto resize', async () => {
     // Set the initial width
     const savedWidth = 42
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))
@@ -84,12 +84,14 @@ describe('ColumnHeader', () => {
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
     expect(measureWidth).toHaveBeenCalledTimes(0)
     await user.dblClick(resizeHandle)
-    // the width is set to undefined, and should then be measured, but the measurement can only run in a browser, so it remains undefined here
-    expect(header.style.maxWidth).toEqual('')
+    // the width is set to undefined, and should then be measured,
+    // but the measurement (.offsetWidth) can only run in a browser,
+    // so its value is 0 + the 1px offset added to avoid rounding errors
+    expect(header.style.maxWidth).toEqual('1px')
     expect(measureWidth).toHaveBeenCalledTimes(1)
   })
 
-  it('handles mouse click and drag to resize', async () => {
+  it('handles mouse click and drag on resize handle to resize', async () => {
     // Set the initial width
     const savedWidth = 42
     localStorage.setItem(cacheKey, JSON.stringify([savedWidth]))

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -210,7 +210,6 @@
       background-color: #f1f1f3;
       /* border: none; */
       border-bottom: 2px solid #c9c9c9;
-      box-sizing: content-box;
       color: #444;
       height: 20px;
       padding-top: 4px;

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DataFrame, sortableDataFrame } from '../../helpers/dataframe.js'
 import { wrapResolved } from '../../utils/promise.js'
 import { render } from '../../utils/userEvent.js'
-import HighTable from './HighTable.js'
+import HighTable, { columnWidthsSuffix } from './HighTable.js'
 
 Element.prototype.scrollIntoView = vi.fn()
 
@@ -740,6 +740,8 @@ describe('in disabled selection state (neither selection nor onSelection props),
 
 const initialWidth = 42
 const measureWidth = vi.fn(() => initialWidth)
+const keyItem = `key${columnWidthsSuffix}`
+const undefinedItem = `undefined${columnWidthsSuffix}`
 vi.mock(import('../../helpers/width.js'), async (importOriginal ) => {
   const actual = await importOriginal()
   return {
@@ -756,7 +758,7 @@ describe('HighTable localstorage', () => {
     }
     expect(header.style.maxWidth).toEqual(`${initialWidth}px`)
     expect(measureWidth).toHaveBeenCalled()
-    expect(localStorage.getItem('key:column-widths')).toEqual(JSON.stringify([initialWidth, initialWidth, initialWidth, initialWidth]))
+    expect(localStorage.getItem(keyItem)).toEqual(JSON.stringify([initialWidth, initialWidth, initialWidth, initialWidth]))
   })
   it('saves nothing on initialization if cacheKey is not provided', () => {
     localStorage.clear()
@@ -767,27 +769,27 @@ describe('HighTable localstorage', () => {
     }
     expect(header.style.maxWidth).toEqual(`${initialWidth}px`)
     expect(measureWidth).toHaveBeenCalled()
-    expect(localStorage.getItem('key:column-widths')).toBeNull()
-    expect(localStorage.getItem('undefined:column-widths')).toBeNull()
+    expect(localStorage.getItem(keyItem)).toBeNull()
+    expect(localStorage.getItem(undefinedItem)).toBeNull()
     expect(localStorage.length).toBe(0)
   })
   it('is used to load previously saved column widths', () => {
     localStorage.clear()
     const savedWidth = initialWidth * 2
-    localStorage.setItem('key:column-widths', JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
+    localStorage.setItem(keyItem, JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
 
     const { getAllByRole } = render(<HighTable data={data} cacheKey="key" />)
     const header = getAllByRole('columnheader')[0]
     if (!header) {
       throw new Error('Header should not be null')
     }
-    expect(localStorage.getItem('key:column-widths')).toEqual(JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
+    expect(localStorage.getItem(keyItem)).toEqual(JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
   })
   it('is updated if new data are loaded', () => {
     localStorage.clear()
     const savedWidth = initialWidth * 2
-    localStorage.setItem('key:column-widths', JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
+    localStorage.setItem(keyItem, JSON.stringify([savedWidth, savedWidth, savedWidth, savedWidth]))
 
     const { getAllByRole, rerender } = render(<HighTable data={data} cacheKey="key" />)
 
@@ -798,7 +800,7 @@ describe('HighTable localstorage', () => {
     if (!header) {
       throw new Error('Header should not be null')
     }
-    expect(localStorage.getItem(`${otherKey}:column-widths`)).toEqual(JSON.stringify([initialWidth, initialWidth]))
+    expect(localStorage.getItem(`${otherKey}${columnWidthsSuffix}`)).toEqual(JSON.stringify([initialWidth, initialWidth]))
     expect(header.style.maxWidth).toEqual(`${initialWidth}px`)
   })
 })

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -54,6 +54,7 @@ interface Props {
 const defaultPadding = 20
 const defaultOverscan = 20
 const ariaOffset = 2 // 1-based index, +1 for the header
+export const columnWidthsSuffix = ':columns:widths' // suffix used to store the column widths in local storage
 
 /**
  * Render a table with streaming rows on demand from a DataFrame.
@@ -82,7 +83,7 @@ function HighTableData(props: PropsData) {
     /* important: key={key} ensures the local state is recreated if the data has changed */
     <OrderByProvider key={key} orderBy={orderBy} onOrderByChange={onOrderByChange} disabled={!data.sortable}>
       <SelectionProvider selection={selection} onSelectionChange={onSelectionChange}>
-        <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}:column-widths` : undefined}>
+        <ColumnWidthProvider localStorageKey={cacheKey ? `${cacheKey}${columnWidthsSuffix}` : undefined}>
           <CellsNavigationProvider colCount={ariaColCount} rowCount={ariaRowCount} rowPadding={props.padding ?? defaultPadding}>
             <HighTableInner {...props} />
           </CellsNavigationProvider>

--- a/src/helpers/width.ts
+++ b/src/helpers/width.ts
@@ -9,9 +9,6 @@ export function leftCellStyle(minWidth: number | undefined) {
 }
 
 export function measureWidth(element: HTMLTableCellElement): number {
-  // get computed cell padding
-  const style = window.getComputedStyle(element)
-  const horizontalPadding = parseInt(style.paddingLeft) + parseInt(style.paddingRight)
   // add 1px to avoid rounding errors, since offsetWidth always returns an integer
-  return element.offsetWidth - horizontalPadding + 1
+  return element.offsetWidth + 1
 }


### PR DESCRIPTION
It simplifies the calculation a lot, by removing the need to get the padding and border.

Note that the measured width is different, and the stored widths in localstorage are obsolete now. This is why we change the localstorage key to invalidate the cache.