### PR TITLE
Adding columnConfiguration property

### DIFF
--- a/src/components/ColumnHeader/ColumnHeader.test.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.test.tsx
@@ -37,7 +37,17 @@ describe('ColumnHeader', () => {
 
   it('renders column header correctly', () => {
     const content = 'test'
-    const { getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps}>{content}</ColumnHeader></tr></thead></table>)
+    const { getByRole } = render(<table><thead><tr><ColumnHeader columnName={content} {...defaultProps}>{content}</ColumnHeader></tr></thead></table>)
+    const element = getByRole('columnheader')
+    expect(element.textContent).toEqual(content)
+    expect(getOffsetWidth).not.toHaveBeenCalled()
+  })
+
+  it('renders headerComponent from columnConfiguration if present', () => {
+    const key = 'test'
+    const content = 'component'
+    const colConfig = { headerComponent: <span>{content}</span> }
+    const { getByRole } = render(<table><thead><tr><ColumnHeader columnName={key} columnConfig={colConfig} {...defaultProps}>{content}</ColumnHeader></tr></thead></table>)
     const element = getByRole('columnheader')
     expect(element.textContent).toEqual(content)
     expect(getOffsetWidth).not.toHaveBeenCalled()

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -5,6 +5,7 @@ import { getOffsetWidth } from '../../helpers/width.js'
 import { useCellNavigation } from '../../hooks/useCellsNavigation.js'
 import { useColumnStates } from '../../hooks/useColumnStates.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
+import { ColumnConfig } from '../../helpers/columnConfiguration.js'
 
 interface Props {
   columnIndex: number // index of the column in the dataframe (0-based)
@@ -18,9 +19,10 @@ interface Props {
   ariaColIndex: number // aria col index for the header
   ariaRowIndex: number // aria row index for the header
   className?: string // optional class name
+  columnConfig?: ColumnConfig
 }
 
-export default function ColumnHeader({ columnIndex, columnName, dataReady, direction, onClick, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
+export default function ColumnHeader({ columnIndex, columnName, columnConfig, dataReady, direction, onClick, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
   const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const handleClick = useCallback(() => {
@@ -119,7 +121,7 @@ export default function ColumnHeader({ columnIndex, columnName, dataReady, direc
       className={className}
       data-fixed-width={dataFixedWidth}
     >
-      {children}
+      {columnConfig?.headerComponent ?? children}
       <ColumnResizer
         forceWidth={forceColumnWidth}
         autoResize={autoResize}

--- a/src/components/HighTable/HighTable.stories.tsx
+++ b/src/components/HighTable/HighTable.stories.tsx
@@ -205,6 +205,20 @@ export const CustomHeaderStyle: Story = {
     columnClassNames: [undefined, undefined, 'delegated'],
   },
 }
+export const HeaderComponent: Story = {
+  args: {
+    data,
+    columnConfiguration: {
+      Double: {
+        headerComponent:
+          <span>
+            Double &nbsp;<button type="button" onClick={() => { alert('Custom function') }}>Button</button>
+          </span>
+        ,
+      },
+    },
+  },
+}
 export const FilteredRows: Story = {
   args: {
     data: filteredData,

--- a/src/components/TableHeader/TableHeader.test.tsx
+++ b/src/components/TableHeader/TableHeader.test.tsx
@@ -3,7 +3,7 @@ import { render } from '../../utils/userEvent.js'
 import TableHeader from './TableHeader.js'
 
 describe('TableHeader', () => {
-  const header = ['Name', 'Age', 'Address']
+  const header = [{ key: 'Name', index: 0 }, { key: 'Age', index: 1 }, { key: 'Address', index: 2 }]
   const dataReady = true
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('TableHeader', () => {
       />
     </tr></thead></table>)
     header.forEach(columnHeader => {
-      expect(getByText(columnHeader)).toBeDefined()
+      expect(getByText(columnHeader.key)).toBeDefined()
     })
   })
 

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from 'react'
 import { OrderBy, toggleColumn } from '../../helpers/sort.js'
 import ColumnHeader from '../ColumnHeader/ColumnHeader.js'
+import { ColumnDescriptor } from '../../hooks/useTableConfig.js'
 
 interface TableProps {
-  header: string[]
+  header: ColumnDescriptor[]
   orderBy?: OrderBy // array of column order by clauses. If undefined, the table is unordered, the sort elements are hidden and the interactions are disabled.
   onOrderByChange?: (orderBy: OrderBy) => void // callback to call when a user interaction changes the order. The interactions are disabled if undefined.
   dataReady: boolean
@@ -29,7 +30,8 @@ export default function TableHeader({
     return new Map((orderBy ?? []).map(({ column, direction }, index) => [column, { direction, index }]))
   }, [orderBy])
 
-  return header.map((name, columnIndex) => {
+  return header.map((colConfig) => {
+    const { key: name, index: columnIndex, ...columnConfig } = colConfig
     // Note: columnIndex is the index of the column in the dataframe header
     // and not the index of the column in the table (which can be different if
     // some columns are hidden, or if the order is changed)
@@ -48,6 +50,7 @@ export default function TableHeader({
         className={columnClassNames[columnIndex]}
         ariaColIndex={ariaColIndex}
         ariaRowIndex={ariaRowIndex}
+        columnConfig={columnConfig}
       >
         {name}
       </ColumnHeader>

--- a/src/helpers/columnConfiguration.ts
+++ b/src/helpers/columnConfiguration.ts
@@ -1,0 +1,14 @@
+import React from 'react'
+
+// Single column config
+export interface ColumnConfig {
+  headerComponent?: React.ReactNode;
+  // width?: number;
+  // hideable?: boolean;
+  // sortable?: boolean;
+  // filters: Some filter structure
+  // cellRenderer?: (value: unknown, row: Row) => React.ReactNode;
+}
+
+// Mapped keys : column config
+export type ColumnConfiguration = Record<string, ColumnConfig>

--- a/src/hooks/useTableConfig.ts
+++ b/src/hooks/useTableConfig.ts
@@ -1,0 +1,36 @@
+// src/hooks/useTableConfig.ts
+import { useMemo } from 'react'
+import { ColumnConfig, ColumnConfiguration } from '../helpers/columnConfiguration'
+
+export interface ColumnDescriptor extends ColumnConfig {
+  key: string; // column name
+  index: number; // position in current order
+}
+
+export function useTableConfig(
+  header: string[],
+  config?: ColumnConfiguration
+): ColumnDescriptor[] {
+  return useMemo(() => {
+    const inHeader = new Set(header)
+
+    // Build descriptors following DataFrame.header order
+    const cols: ColumnDescriptor[] = header.map((key, i) => ({
+      key,
+      index: i,
+      ...config?.[key] ?? {},
+    }))
+
+    if (config) {
+      for (const k of Object.keys(config)) {
+        if (!inHeader.has(k)) {
+          console.warn(
+            `[HighTable] columnConfiguration has unknown key “${k}”. It will be ignored.`
+          )
+        }
+      }
+    }
+
+    return cols
+  }, [header, config])
+}

--- a/test/hooks/useTableConfig.test.tsx
+++ b/test/hooks/useTableConfig.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+
+import { useTableConfig } from '../../src/hooks/useTableConfig'
+import { ColumnConfiguration } from '../../src/helpers/columnConfiguration'
+
+afterEach(cleanup)
+
+describe('useTableConfig', () => {
+  it('returns descriptors in DataFrame header order', () => {
+    const header = ['id', 'name', 'status']
+
+    const { result } = renderHook(() => useTableConfig(header, undefined))
+
+    expect(result.current.map(c => c.key)).toEqual(header)
+    expect(result.current.map(c => c.index)).toEqual([0, 1, 2])
+  })
+
+  it('merges columnConfiguration props into descriptors', () => {
+    const header = ['id', 'name']
+    const columnConfiguration: ColumnConfiguration = {
+      name: { headerComponent: <strong>Name</strong> },
+    }
+
+    const { result } = renderHook(() =>
+      useTableConfig(header, columnConfiguration)
+    )
+
+    const [, nameCol] = result.current
+    expect(nameCol.key).toBe('name')
+    expect(nameCol.headerComponent).toMatchInlineSnapshot(`
+      <strong>
+        Name
+      </strong>
+    `)
+  })
+
+  it('ignores configuration keys that are not in DataFrame.header', () => {
+    const header = ['id']
+    const columnConfiguration = {
+      id: { width: 50 },
+      extraneous: { width: 123 },
+    } as unknown as ColumnConfiguration // stray key on purpose
+
+    const { result } = renderHook(() =>
+      useTableConfig(header, columnConfiguration)
+    )
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].key).toBe('id')
+  })
+
+  it('returns a stable reference when inputs are unchanged', () => {
+    const header = ['id']
+
+    const { result, rerender } = renderHook(
+      ({ h, c }: { h: string[]; c?: ColumnConfiguration }) =>
+        useTableConfig(h, c),
+      { initialProps: { h: header, c: undefined } }
+    )
+
+    const first = result.current
+    rerender({ h: header, c: undefined })
+
+    // React memo should give us the same array instance
+    expect(result.current).toBe(first)
+  })
+})


### PR DESCRIPTION
Added a columnConfiguration property which currently only has 1 property but can be extended later. Currently, only allows headerComponent which enables users to render custom react components in the column header cell.