### PR TITLE
Hide columns

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,7 +1,7 @@
 import { KeyboardEvent, MouseEvent, ReactNode, useCallback, useMemo, useRef } from 'react'
 import { ResolvedValue } from '../../helpers/dataframe/index.js'
 import { useCellNavigation } from '../../hooks/useCellsNavigation.js'
-import { useColumnStates } from '../../hooks/useColumnStates.js'
+import { useColumnWidths } from '../../hooks/useColumnWidths.js'
 
 export interface CellContentProps {
   stringify: (value: unknown) => string | undefined
@@ -63,7 +63,7 @@ export default function Cell({ cell, onDoubleClickCell, onMouseDownCell, onKeyDo
   }, [onKeyDownCell, rowNumber, columnIndex])
 
   // Get the column width from the context
-  const { getColumnStyle } = useColumnStates()
+  const { getColumnStyle } = useColumnWidths()
   const columnStyle = getColumnStyle?.(columnIndex)
 
   // render as truncated text

--- a/src/components/ColumnHeader/ColumnHeader.test.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ColumnStatesProvider } from '../../hooks/useColumnStates.js'
+import { ColumnWidthsProvider } from '../../hooks/useColumnWidths.js'
 import { render } from '../../utils/userEvent.js'
 import ColumnHeader from './ColumnHeader.js'
 
@@ -77,9 +77,9 @@ describe('ColumnHeader', () => {
     const savedWidth = 42
     localStorage.setItem(cacheKey, JSON.stringify([{ width: savedWidth }]))
 
-    const { getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
+    const { getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
       <table><thead><tr><ColumnHeader columnName="test" {...defaultProps}/></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(`${savedWidth}px`)
   })
@@ -90,9 +90,9 @@ describe('ColumnHeader', () => {
   ])('clamps loaded column width from localStorage when localStorageKey is provided', ({ savedWidth, minWidth, expected }) => {
     localStorage.setItem(cacheKey, JSON.stringify([{ width: savedWidth }]))
 
-    const { getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={minWidth}>
+    const { getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={minWidth}>
       <table><thead><tr><ColumnHeader columnName="test" {...defaultProps}/></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(expected)
   })
@@ -103,9 +103,9 @@ describe('ColumnHeader', () => {
     const minWidth = 10
     localStorage.setItem(cacheKey, JSON.stringify([{ width: savedWidth }]))
 
-    const { user, getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={minWidth}>
+    const { user, getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={minWidth}>
       <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('spinbutton')
 
@@ -125,9 +125,9 @@ describe('ColumnHeader', () => {
     const savedWidth = 42
     localStorage.setItem(cacheKey, JSON.stringify([{ width: savedWidth }]))
 
-    const { user, getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
+    const { user, getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
       <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
 
     // Simulate resizing the column
     const header = getByRole('columnheader')
@@ -155,9 +155,9 @@ describe('ColumnHeader', () => {
     const columnConfig = { minWidth: columnMinWidth }
     const props = { ...defaultProps, columnConfig }
 
-    const { user, getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
+    const { user, getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
       <table><thead><tr><ColumnHeader columnName="test" {...props} /></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
 
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('spinbutton')
@@ -184,9 +184,9 @@ describe('ColumnHeader', () => {
     const columnConfig = { minWidth: columnMinWidth }
     const props = { ...defaultProps, columnConfig }
 
-    const { user, getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={globalMinWidth}>
+    const { user, getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={globalMinWidth}>
       <table><thead><tr><ColumnHeader columnName="test" {...props} /></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
 
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('spinbutton')
@@ -211,14 +211,14 @@ describe('ColumnHeader', () => {
     const width2 = 300
     localStorage.setItem(cacheKey2, JSON.stringify([{ width: width2 }]))
 
-    const { rerender, getByRole } = render(<ColumnStatesProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
+    const { rerender, getByRole } = render(<ColumnWidthsProvider localStorageKey={cacheKey} numColumns={1} minWidth={10}>
       <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
     const header = getByRole('columnheader')
     expect(header.style.maxWidth).toEqual(`${width1}px`)
-    rerender(<ColumnStatesProvider localStorageKey={cacheKey2} numColumns={1} minWidth={10}>
+    rerender(<ColumnWidthsProvider localStorageKey={cacheKey2} numColumns={1} minWidth={10}>
       <table><thead><tr><ColumnHeader columnName="test" {...defaultProps} /></tr></thead></table>
-    </ColumnStatesProvider>)
+    </ColumnWidthsProvider>)
     expect(header.style.maxWidth).toEqual(`${width2}px`)
   })
 

--- a/src/components/ColumnHeader/ColumnHeader.test.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.test.tsx
@@ -222,45 +222,45 @@ describe('ColumnHeader', () => {
     expect(header.style.maxWidth).toEqual(`${width2}px`)
   })
 
-  it('call onClick (eg. to change orderBy) when clicking on the header, but not when clicking on the resize handle', async () => {
-    const onClick = vi.fn()
-    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} onClick={onClick} /></tr></thead></table>)
+  it('call toggleOrderBy (eg. to change orderBy) when clicking on the header, but not when clicking on the resize handle', async () => {
+    const toggleOrderBy = vi.fn()
+    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} toggleOrderBy={toggleOrderBy} /></tr></thead></table>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('spinbutton')
     await user.click(resizeHandle)
-    expect(onClick).not.toHaveBeenCalled()
+    expect(toggleOrderBy).not.toHaveBeenCalled()
     await user.click(header)
-    expect(onClick).toHaveBeenCalled()
+    expect(toggleOrderBy).toHaveBeenCalled()
   })
 
-  it.for(['{ }', '{Enter}'])('call onClick (eg. to change orderBy) when pressing "%s" while the header is focused', async (key) => {
-    const onClick = vi.fn()
-    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} onClick={onClick} /></tr></thead></table>)
+  it.for(['{ }', '{Enter}'])('call toggleOrderBy (eg. to change orderBy) when pressing "%s" while the header is focused', async (key) => {
+    const toggleOrderBy = vi.fn()
+    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...defaultProps} toggleOrderBy={toggleOrderBy} /></tr></thead></table>)
     const header = getByRole('columnheader')
     header.focus()
     await user.keyboard(key)
-    expect(onClick).toHaveBeenCalled()
+    expect(toggleOrderBy).toHaveBeenCalled()
   })
 
-  it('does not call onClick when clicking on the header when sortable is set to false', async () => {
-    const onClick = vi.fn()
+  it('does not call toggleOrderBy when clicking on the header when sortable is set to false', async () => {
+    const toggleOrderBy = vi.fn()
     const props = { ...defaultProps, sortable: false }
-    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...props} onClick={onClick} /></tr></thead></table>)
+    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...props} toggleOrderBy={toggleOrderBy} /></tr></thead></table>)
     const header = getByRole('columnheader')
     const resizeHandle = getByRole('spinbutton')
     await user.click(resizeHandle)
-    expect(onClick).not.toHaveBeenCalled()
+    expect(toggleOrderBy).not.toHaveBeenCalled()
     await user.click(header)
-    expect(onClick).toHaveBeenCalled()
+    expect(toggleOrderBy).toHaveBeenCalled()
   })
 
-  it.for(['{ }', '{Enter}'])('does not call onClick when pressing "%s" while the header is focused', async (key) => {
-    const onClick = vi.fn()
+  it.for(['{ }', '{Enter}'])('does not call toggleOrderBy when pressing "%s" while the header is focused', async (key) => {
+    const toggleOrderBy = vi.fn()
     const props = { ...defaultProps, sortable: false }
-    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...props} onClick={onClick} /></tr></thead></table>)
+    const { user, getByRole } = render(<table><thead><tr><ColumnHeader columnName="test" {...props} toggleOrderBy={toggleOrderBy} /></tr></thead></table>)
     const header = getByRole('columnheader')
     header.focus()
     await user.keyboard(key)
-    expect(onClick).toHaveBeenCalled()
+    expect(toggleOrderBy).toHaveBeenCalled()
   })
 })

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -17,7 +17,7 @@ interface Props {
   children?: ReactNode
   canMeasureWidth?: boolean
   direction?: Direction
-  onClick?: () => void
+  toggleOrderBy?: () => void
   orderByIndex?: number // index of the column in the orderBy array (0-based)
   orderBySize?: number // size of the orderBy array
   ariaColIndex: number // aria col index for the header
@@ -25,16 +25,16 @@ interface Props {
   className?: string // optional class name
 }
 
-export default function ColumnHeader({ columnIndex, columnName, columnConfig, canMeasureWidth, direction, onClick, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
+export default function ColumnHeader({ columnIndex, columnName, columnConfig, canMeasureWidth, direction, toggleOrderBy, orderByIndex, orderBySize, ariaColIndex, ariaRowIndex, className, children }: Props) {
   const ref = useRef<HTMLTableCellElement>(null)
   const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const { sortable, headerComponent } = columnConfig
-  const { isOpen, position, menuId, handleToggle, handleMenuClick } = useColumnMenu(ref, navigateToCell)
+  const { isOpen, position, menuId, close, handleMenuClick } = useColumnMenu(ref, navigateToCell)
 
   const handleClick = useCallback(() => {
     navigateToCell()
-    if (sortable) onClick?.()
-  }, [onClick, navigateToCell, sortable])
+    if (sortable) toggleOrderBy?.()
+  }, [toggleOrderBy, navigateToCell, sortable])
 
   // Get the column width from the context
   const { getColumnStyle, isFixedColumn, getColumnWidth, measureWidth, forceWidth, removeWidth } = useColumnStates()
@@ -102,9 +102,9 @@ export default function ColumnHeader({ columnIndex, columnName, columnConfig, ca
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       e.stopPropagation()
-      onClick?.()
+      toggleOrderBy?.()
     }
-  }, [onClick])
+  }, [toggleOrderBy])
 
   return (
     <th
@@ -150,8 +150,8 @@ export default function ColumnHeader({ columnIndex, columnName, columnConfig, ca
         position={position}
         direction={direction}
         sortable={sortable}
-        onClick={onClick}
-        onToggle={handleToggle}
+        toggleOrderBy={toggleOrderBy}
+        close={close}
         id={menuId}
       />
     </th>

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -6,6 +6,7 @@ import { getOffsetWidth } from '../../helpers/width.js'
 import { useCellNavigation } from '../../hooks/useCellsNavigation.js'
 import { useColumnMenu } from '../../hooks/useColumnMenu.js'
 import { useColumnWidths } from '../../hooks/useColumnWidths.js'
+import { useColumnVisibilityStates } from '../../hooks/useColumnVisibilityStates.js'
 import ColumnMenu from '../ColumnMenu/ColumnMenu.js'
 import ColumnMenuButton from '../ColumnMenuButton/ColumnMenuButton.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
@@ -30,11 +31,21 @@ export default function ColumnHeader({ columnIndex, columnName, columnConfig, ca
   const { tabIndex, navigateToCell } = useCellNavigation({ ref, ariaColIndex, ariaRowIndex })
   const { sortable, headerComponent } = columnConfig
   const { isOpen, position, menuId, close, handleMenuClick } = useColumnMenu(ref, navigateToCell)
+  const { getHideColumn, showAllColumns } = useColumnVisibilityStates()
 
   const handleClick = useCallback(() => {
     navigateToCell()
     if (sortable) toggleOrderBy?.()
   }, [toggleOrderBy, navigateToCell, sortable])
+
+  const hideColumn = useMemo(() => {
+    return getHideColumn?.(columnIndex)
+  }, [getHideColumn, columnIndex])
+
+  const isMenuEnabled = useMemo(() => {
+    const hideMenu = !sortable && !hideColumn && !showAllColumns
+    return !hideMenu
+  }, [sortable, hideColumn, showAllColumns])
 
   // Get the column width from the context
   const { getColumnStyle, isFixedColumn, getColumnWidth, measureWidth, forceWidth, removeWidth } = useColumnWidths()
@@ -127,7 +138,7 @@ export default function ColumnHeader({ columnIndex, columnName, columnConfig, ca
       data-fixed-width={dataFixedWidth}
     >
       {headerComponent ?? children}
-      {sortable &&
+      {isMenuEnabled &&
         <ColumnMenuButton
           onClick={handleMenuClick}
           onEscape={navigateToCell}
@@ -151,6 +162,8 @@ export default function ColumnHeader({ columnIndex, columnName, columnConfig, ca
         direction={direction}
         sortable={sortable}
         toggleOrderBy={toggleOrderBy}
+        hideColumn={hideColumn}
+        showAllColumns={showAllColumns}
         close={close}
         id={menuId}
       />

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -5,7 +5,7 @@ import { Direction } from '../../helpers/sort.js'
 import { getOffsetWidth } from '../../helpers/width.js'
 import { useCellNavigation } from '../../hooks/useCellsNavigation.js'
 import { useColumnMenu } from '../../hooks/useColumnMenu.js'
-import { useColumnStates } from '../../hooks/useColumnStates.js'
+import { useColumnWidths } from '../../hooks/useColumnWidths.js'
 import ColumnMenu from '../ColumnMenu/ColumnMenu.js'
 import ColumnMenuButton from '../ColumnMenuButton/ColumnMenuButton.js'
 import ColumnResizer from '../ColumnResizer/ColumnResizer.js'
@@ -37,7 +37,7 @@ export default function ColumnHeader({ columnIndex, columnName, columnConfig, ca
   }, [toggleOrderBy, navigateToCell, sortable])
 
   // Get the column width from the context
-  const { getColumnStyle, isFixedColumn, getColumnWidth, measureWidth, forceWidth, removeWidth } = useColumnStates()
+  const { getColumnStyle, isFixedColumn, getColumnWidth, measureWidth, forceWidth, removeWidth } = useColumnWidths()
   const columnStyle = getColumnStyle?.(columnIndex)
   const dataFixedWidth = isFixedColumn?.(columnIndex) === true ? true : undefined
   const width = getColumnWidth?.(columnIndex)

--- a/src/components/ColumnMenu/ColumnMenu.test.tsx
+++ b/src/components/ColumnMenu/ColumnMenu.test.tsx
@@ -8,7 +8,7 @@ describe('ColumnMenu', () => {
     isOpen: true,
     position: { left: 100, top: 100 },
     columnIndex: 0,
-    onToggle: vi.fn(),
+    close: vi.fn(),
   }
 
   beforeEach(() => {
@@ -111,15 +111,15 @@ describe('ColumnMenu', () => {
       expect(menuItem.getAttribute('type')).toBe('button')
     })
 
-    it('calls onClick when sort button is clicked', async () => {
-      const onClick = vi.fn()
+    it('calls toggleOrderBy when sort button is clicked', async () => {
+      const toggleOrderBy = vi.fn()
       const { user, getByRole } = render(
-        <ColumnMenu {...defaultProps} sortable={true} onClick={onClick} />
+        <ColumnMenu {...defaultProps} sortable={true} toggleOrderBy={toggleOrderBy} />
       )
 
       const sortButton = getByRole('menuitem')
       await user.click(sortButton)
-      expect(onClick).toHaveBeenCalled()
+      expect(toggleOrderBy).toHaveBeenCalled()
     })
 
     it('focuses button when clicked', async () => {
@@ -141,33 +141,33 @@ describe('ColumnMenu', () => {
       menu.focus()
       await user.keyboard('{Escape}')
 
-      expect(defaultProps.onToggle).toHaveBeenCalled()
+      expect(defaultProps.close).toHaveBeenCalled()
     })
 
-    it('calls onClick on Enter key when sortable', async () => {
-      const onClick = vi.fn()
+    it('calls toggleOrderBy on Enter key when sortable', async () => {
+      const toggleOrderBy = vi.fn()
       const { user, getByRole } = render(
-        <ColumnMenu {...defaultProps} sortable={true} onClick={onClick} />
+        <ColumnMenu {...defaultProps} sortable={true} toggleOrderBy={toggleOrderBy} />
       )
 
       const sortButton = getByRole('menuitem')
       sortButton.focus()
       await user.keyboard('{Enter}')
 
-      expect(onClick).toHaveBeenCalled()
+      expect(toggleOrderBy).toHaveBeenCalled()
     })
 
-    it('calls onClick on Space key when sortable', async () => {
-      const onClick = vi.fn()
+    it('calls toggleOrderBy on Space key when sortable', async () => {
+      const toggleOrderBy = vi.fn()
       const { user, getByRole } = render(
-        <ColumnMenu {...defaultProps} sortable={true} onClick={onClick} />
+        <ColumnMenu {...defaultProps} sortable={true} toggleOrderBy={toggleOrderBy} />
       )
 
       const sortButton = getByRole('menuitem')
       sortButton.focus()
       await user.keyboard('{ }')
 
-      expect(onClick).toHaveBeenCalled()
+      expect(toggleOrderBy).toHaveBeenCalled()
     })
 
     // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not. The menu only has one item, so the keys are useless.
@@ -314,7 +314,7 @@ describe('ColumnMenu', () => {
 
       if (overlay) {
         await user.click(overlay)
-        expect(defaultProps.onToggle).toHaveBeenCalled()
+        expect(defaultProps.close).toHaveBeenCalled()
       }
     })
   })
@@ -333,7 +333,7 @@ describe('ColumnMenu', () => {
   })
 
   describe('Edge cases', () => {
-    it('works without onClick handler', () => {
+    it('works without toggleOrderBy handler', () => {
       const { getByRole } = render(
         <ColumnMenu {...defaultProps} sortable={true} />
       )

--- a/src/components/ColumnMenu/ColumnMenu.test.tsx
+++ b/src/components/ColumnMenu/ColumnMenu.test.tsx
@@ -100,6 +100,51 @@ describe('ColumnMenu', () => {
     })
   })
 
+  describe('Visibility options', () => {
+    it('renders hide column option when hideColumn is provided', () => {
+      const hideColumn = vi.fn()
+      const { getByText } = render(
+        <ColumnMenu {...defaultProps} hideColumn={hideColumn} />
+      )
+      const hideOption = getByText('Hide column')
+      expect(hideOption).toBeDefined()
+      hideOption.click()
+      expect(hideColumn).toHaveBeenCalled()
+    })
+    it('does not render hide column option when hideColumn is not provided', () => {
+      const { queryByText } = render(<ColumnMenu {...defaultProps} />)
+
+      expect(queryByText('Hide column')).toBeNull()
+    })
+    it('renders show all columns option when showAllColumns is provided', () => {
+      const showAllColumns = vi.fn()
+      const { getByText } = render(
+        <ColumnMenu {...defaultProps} showAllColumns={showAllColumns} />
+      )
+      const showOption = getByText('Show all columns')
+      expect(showOption).toBeDefined()
+      showOption.click()
+      expect(showAllColumns).toHaveBeenCalled()
+    })
+    it('does not render show all columns option when showAllColumns is not provided', () => {
+      const { queryByText } = render(<ColumnMenu {...defaultProps} />)
+      expect(queryByText('Show all columns')).toBeNull()
+    })
+    it('render both hide and show options when both are provided', () => {
+      const hideColumn = vi.fn()
+      const showAllColumns = vi.fn()
+      const { getByText } = render(
+        <ColumnMenu
+          {...defaultProps}
+          hideColumn={hideColumn}
+          showAllColumns={showAllColumns}
+        />
+      )
+      expect(getByText('Hide column')).toBeDefined()
+      expect(getByText('Show all columns')).toBeDefined()
+    })
+  })
+
   describe('MenuItem component', () => {
     it('renders with correct ARIA attributes', () => {
       const { getByRole } = render(
@@ -170,11 +215,11 @@ describe('ColumnMenu', () => {
       expect(toggleOrderBy).toHaveBeenCalled()
     })
 
-    // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not. The menu only has one item, so the keys are useless.
+    // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not.
     describe('Arrow key navigation', () => {
       it('handles ArrowUp key', async () => {
         const { user, getByRole } = render(
-          <ColumnMenu {...defaultProps} sortable={true} />
+          <ColumnMenu {...defaultProps} sortable={true} hideColumn={() => undefined} />
         )
 
         const menu = getByRole('menu')
@@ -222,7 +267,7 @@ describe('ColumnMenu', () => {
       })
     })
 
-    // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not. The menu only has one item, so the keys are useless.
+    // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not.
     describe('Tab navigation', () => {
       it('handles Tab key', async () => {
         const { user, getByRole } = render(
@@ -249,7 +294,7 @@ describe('ColumnMenu', () => {
       })
     })
 
-    // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not. The menu only has one item, so the keys are useless.
+    // TODO(SL): really test the navigation. For now, it works the same if the key is pressed or not.
     describe('Home/End keys', () => {
       it('handles Home key', async () => {
         const { user, getByRole } = render(

--- a/src/components/ColumnMenu/ColumnMenu.tsx
+++ b/src/components/ColumnMenu/ColumnMenu.tsx
@@ -65,8 +65,8 @@ interface ColumnMenuProps {
   }
   direction?: Direction
   sortable?: boolean
-  onClick?: () => void
-  onToggle: () => void
+  toggleOrderBy?: () => void
+  close: () => void
   id?: string
 }
 
@@ -76,8 +76,8 @@ export default function ColumnMenu({
   position,
   direction,
   sortable,
-  onClick,
-  onToggle,
+  toggleOrderBy,
+  close,
   id,
 }: ColumnMenuProps) {
   const { containerRef } = usePortalContainer()
@@ -92,7 +92,7 @@ export default function ColumnMenu({
     e.stopPropagation()
     switch (e.key) {
     case 'Escape':
-      onToggle()
+      close()
       break
     case 'Enter':
     case ' ':
@@ -116,15 +116,15 @@ export default function ColumnMenu({
       navigateFocus(e.shiftKey ? 'previous' : 'next')
       break
     }
-  }, [navigateFocus, onToggle] )
+  }, [navigateFocus, close])
 
   const handleOverlayClick = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
       e.preventDefault()
       e.stopPropagation()
-      onToggle()
+      close()
     },
-    [onToggle]
+    [close]
   )
 
   const onWrapperClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
@@ -156,7 +156,7 @@ export default function ColumnMenu({
       >
         <div role='presentation' id={labelId} aria-hidden="true">{columnName}</div>
         {sortable && <MenuItem
-          onClick={onClick}
+          onClick={toggleOrderBy}
           label={sortDirection}
         />}
       </div>

--- a/src/components/ColumnMenu/ColumnMenu.tsx
+++ b/src/components/ColumnMenu/ColumnMenu.tsx
@@ -1,6 +1,7 @@
 import { KeyboardEvent, MouseEvent, ReactNode, useCallback, useId, useMemo, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { Direction } from '../../helpers/sort'
+import { useCellsNavigation } from '../../hooks/useCellsNavigation'
 import { useFocusManagement } from '../../hooks/useFocusManagement'
 import { usePortalContainer } from '../../hooks/usePortalContainer'
 
@@ -104,6 +105,7 @@ export default function ColumnMenu({
   const labelId = useId()
 
   const { navigateFocus } = useFocusManagement(isOpen, menuRef)
+  const { focusFirstCell } = useCellsNavigation()
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
     e.preventDefault()
@@ -158,10 +160,11 @@ export default function ColumnMenu({
     }
     return () => {
       hideColumn()
-      // TODO(SL): we must decide where to put the focus once the menu is closed, since the column will disappear
+      // We focus the top left cell, which will always exist, because this column will disappear
+      focusFirstCell?.()
       close()
     }
-  }, [hideColumn, close])
+  }, [hideColumn, close, focusFirstCell])
 
   const showAllColumnsAndClose = useMemo(() => {
     if (!showAllColumns) {

--- a/src/components/HighTable/HighTable.module.css
+++ b/src/components/HighTable/HighTable.module.css
@@ -89,7 +89,7 @@
     th {
       & > button {
         position: absolute;
-        right: 12px;
+        right: 6px;
         top: 50%;
         transform: translateY(-50%);
         width: 20px;
@@ -339,6 +339,16 @@
     & > [role="presentation"] {
       padding: 4px 12px 8px;
       font-weight: bold;
+      border-style: solid;
+      border-color: var(--light-border-color);
+      border-width: 0 0 1px 0;
+    }
+
+    & > [role="separator"] {
+      display: block;
+      width: 100%;
+      text-align: left;
+      padding: 4px 12px;
     }
 
     & > [role="menuitem"] {

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -5,9 +5,9 @@ import { createGetRowNumber, createStaticFetch, validateColumn, validateFetchPar
 import { DataFrame, DataFrameEvents, UnsortableDataFrame, filterDataFrame } from '../../helpers/dataframe/index.js'
 import { sortableDataFrame } from '../../helpers/dataframe/sort.js'
 import { createEventTarget } from '../../helpers/typedEventTarget.js'
-import { MaybeColumnState } from '../../hooks/useColumnStates.js'
+import { MaybeColumnWidth } from '../../helpers/width.js'
 import { render } from '../../utils/userEvent.js'
-import HighTable, { columnStatesSuffix, defaultOverscan } from './HighTable.js'
+import HighTable, { columnWidthsSuffix, defaultOverscan } from './HighTable.js'
 
 Element.prototype.scrollIntoView = vi.fn()
 
@@ -1005,8 +1005,8 @@ describe('in disabled selection state (neither selection nor onSelection props),
 const initialWidth = 62 // initial width of the columns, in pixels, above the default minimal width of 50px
 const getOffsetWidth = vi.fn(() => initialWidth)
 const getClientWidth = vi.fn(() => 1000) // used to get the width of the table - let's give space
-const keyItem = `key${columnStatesSuffix}`
-const undefinedItem = `undefined${columnStatesSuffix}`
+const keyItem = `key${columnWidthsSuffix}`
+const undefinedItem = `undefined${columnWidthsSuffix}`
 vi.mock(import('../../helpers/width.js'), async (importOriginal ) => {
   const actual = await importOriginal()
   return {
@@ -1029,11 +1029,11 @@ describe('HighTable localstorage', () => {
     expect(getClientWidth).toHaveBeenCalled()
     const json = localStorage.getItem(keyItem)
     expect(json).not.toEqual(null)
-    const columnStates = JSON.parse(json ?? '[]') as MaybeColumnState[] // TODO: we could check the type of the column states
-    expect(columnStates).toHaveLength(4) // 4 columns
-    columnStates.forEach((columnState) => {
-      expect(columnState?.measured).toBeUndefined() // the measured field is not stored
-      expect(columnState?.width).toBeUndefined() // no columns is fixed
+    const columnWidths = JSON.parse(json ?? '[]') as MaybeColumnWidth[] // TODO: we could check the type of the column widths
+    expect(columnWidths).toHaveLength(4) // 4 columns
+    columnWidths.forEach((columnWidth) => {
+      expect(columnWidth?.measured).toBeUndefined() // the measured field is not stored
+      expect(columnWidth?.width).toBeUndefined() // no columns is fixed
     })
   })
   it('saves nothing on initialization if cacheKey is not provided', () => {
@@ -1071,11 +1071,11 @@ describe('HighTable localstorage', () => {
 
     const json = localStorage.getItem(keyItem)
     expect(json).not.toEqual(null)
-    const columnStates = JSON.parse(json ?? '[]') as MaybeColumnState[]
-    expect(columnStates).toHaveLength(4) // 4 columns
-    columnStates.forEach((columnState) => {
-      expect(columnState?.measured).toBeUndefined() // the measured field is not stored
-      expect(columnState?.width).toBeDefined() // all columns should have been adjusted to some width
+    const columnWidths = JSON.parse(json ?? '[]') as MaybeColumnWidth[]
+    expect(columnWidths).toHaveLength(4) // 4 columns
+    columnWidths.forEach((columnWidth) => {
+      expect(columnWidth?.measured).toBeUndefined() // the measured field is not stored
+      expect(columnWidth?.width).toBeDefined() // all columns should have been adjusted to some width
     })
   })
   it('the previous data is used or updated if new data are loaded', () => {
@@ -1093,7 +1093,7 @@ describe('HighTable localstorage', () => {
     if (!header) {
       throw new Error('Header should not be null')
     }
-    expect(localStorage.getItem(`${otherKey}${columnStatesSuffix}`)).not.toEqual(localStorage.getItem(keyItem))
+    expect(localStorage.getItem(`${otherKey}${columnWidthsSuffix}`)).not.toEqual(localStorage.getItem(keyItem))
     expect(header.style.maxWidth).not.toEqual(`${savedWidth}px`)
   })
 })

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -5,10 +5,9 @@ import { createGetRowNumber, createStaticFetch, validateColumn, validateFetchPar
 import { DataFrame, DataFrameEvents, UnsortableDataFrame, filterDataFrame } from '../../helpers/dataframe/index.js'
 import { sortableDataFrame } from '../../helpers/dataframe/sort.js'
 import { createEventTarget } from '../../helpers/typedEventTarget.js'
-import { MaybeHiddenColumn } from '../../hooks/useColumnVisibilityStates.js'
 import { MaybeColumnWidth } from '../../helpers/width.js'
 import { render } from '../../utils/userEvent.js'
-import HighTable, { columnVisibilityStatesSuffix, columnWidthsSuffix, defaultOverscan } from './HighTable.js'
+import HighTable, { columnWidthsSuffix, defaultOverscan } from './HighTable.js'
 
 Element.prototype.scrollIntoView = vi.fn()
 

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -1220,18 +1220,32 @@ describe('Navigating Hightable with the keyboard', () => {
   })
 
   describe('When a header cell is focused', () => {
-    it('the column resizer and the header cell are focusable', async () => {
+    it('the column resizer, the menu button and the header cell are focusable', async () => {
       const { user } = render(<HighTable data={data} />)
       // go to the header cell (ID)
       await user.keyboard('{ArrowRight}')
       const cell = document.activeElement
+      // Tab focuses the menu button
+      await user.keyboard('{Tab}')
+      let focusedElement = document.activeElement
+      if (!focusedElement) {
+        throw new Error('Focused element not found')
+      }
+      expect(focusedElement.tagName.toLowerCase()).toBe('button')
       // Tab focuses the column resizer
       await user.keyboard('{Tab}')
-      const focusedElement = document.activeElement
+      focusedElement = document.activeElement
       if (!focusedElement) {
         throw new Error('Focused element not found')
       }
       expect(focusedElement.getAttribute('role')).toBe('spinbutton')
+      // Shift+Tab focuses the menu button again
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+      focusedElement = document.activeElement
+      if (!focusedElement) {
+        throw new Error('Focused element not found')
+      }
+      expect(focusedElement.tagName.toLowerCase()).toBe('button')
       // Shift+Tab focuses the header cell again
       await user.keyboard('{Shift>}{Tab}{/Shift}')
       expect(document.activeElement).toBe(cell)
@@ -1242,7 +1256,7 @@ describe('Navigating Hightable with the keyboard', () => {
       // go to the column resizer
       await user.keyboard('{ArrowRight}')
       const cell = document.activeElement
-      await user.keyboard('{Tab}')
+      await user.keyboard('{Tab}{Tab}')
       // press Enter to activate the column resizer
       const spinbutton = document.activeElement
       if (!spinbutton) {
@@ -1258,7 +1272,7 @@ describe('Navigating Hightable with the keyboard', () => {
     it('the column resizer changes the column width when ArrowRight, ArrowLeft, ArrowUp, ArrowDown, ArrowPageUp, ArrowPageDown and Home are pressed', async () => {
       const { user } = render(<HighTable data={data} />)
       // go to the column resizer
-      await user.keyboard('{ArrowRight}{Tab}')
+      await user.keyboard('{ArrowRight}{Tab}{Tab}')
       const spinbutton = document.activeElement
       if (!spinbutton) {
         throw new Error('Spinbutton is null')
@@ -1289,7 +1303,7 @@ describe('Navigating Hightable with the keyboard', () => {
       // go to the column resizer
       await user.keyboard('{ArrowRight}')
       const cell = document.activeElement
-      await user.keyboard('{Tab}')
+      await user.keyboard('{Tab}{Tab}')
       const spinbutton = document.activeElement
       if (!spinbutton) {
         throw new Error('Spinbutton is null')
@@ -1313,7 +1327,7 @@ describe('Navigating Hightable with the keyboard', () => {
     it.for(['{ }', '{Enter}'])('the column resizer toggles back to adjustable column when %s is pressed if previously autosized', async (key) => {
       const { user } = render(<HighTable data={data} />)
       // go to the column resizer
-      await user.keyboard('{ArrowRight}{Tab}')
+      await user.keyboard('{ArrowRight}{Tab}{Tab}')
       const spinbutton = document.activeElement
       if (!spinbutton) {
         throw new Error('Spinbutton is null')
@@ -1323,7 +1337,7 @@ describe('Navigating Hightable with the keyboard', () => {
       await user.keyboard(key)
       expect(spinbutton.getAttribute('aria-valuenow')).not.toBe(initialValue)
       // focus the resizer again
-      await user.keyboard('{Tab}')
+      await user.keyboard('{Tab}{Tab}')
       // press the key
       await user.keyboard(key)
       // already autosized - toggles to adjustable width

--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -5,9 +5,10 @@ import { createGetRowNumber, createStaticFetch, validateColumn, validateFetchPar
 import { DataFrame, DataFrameEvents, UnsortableDataFrame, filterDataFrame } from '../../helpers/dataframe/index.js'
 import { sortableDataFrame } from '../../helpers/dataframe/sort.js'
 import { createEventTarget } from '../../helpers/typedEventTarget.js'
+import { MaybeHiddenColumn } from '../../hooks/useColumnVisibilityStates.js'
 import { MaybeColumnWidth } from '../../helpers/width.js'
 import { render } from '../../utils/userEvent.js'
-import HighTable, { columnWidthsSuffix, defaultOverscan } from './HighTable.js'
+import HighTable, { columnVisibilityStatesSuffix, columnWidthsSuffix, defaultOverscan } from './HighTable.js'
 
 Element.prototype.scrollIntoView = vi.fn()
 

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -5,7 +5,7 @@ import { Selection } from '../../helpers/selection.js'
 import { OrderBy } from '../../helpers/sort.js'
 import { cellStyle, getClientWidth, getOffsetWidth } from '../../helpers/width.js'
 import { CellsNavigationProvider, useCellsNavigation } from '../../hooks/useCellsNavigation.js'
-import { ColumnStatesProvider, useColumnStates } from '../../hooks/useColumnStates.js'
+import { ColumnWidthsProvider, useColumnWidths } from '../../hooks/useColumnWidths.js'
 import { DataProvider, useData } from '../../hooks/useData.js'
 import { OrderByProvider, useOrderBy } from '../../hooks/useOrderBy.js'
 import { PortalContainerProvider, usePortalContainer } from '../../hooks/usePortalContainer.js'
@@ -49,7 +49,9 @@ interface Props {
 const defaultPadding = 20
 export const defaultOverscan = 20
 const ariaOffset = 2 // 1-based index, +1 for the header
-export const columnStatesSuffix = ':column:states' // suffix used to store the column states in local storage
+
+const formatVersion = '1' // increase in case of breaking changes in the column widths format
+export const columnWidthsSuffix = `:${formatVersion}:column:widths` // suffix used to store the column widths in local storage
 
 /**
  * Render a table with streaming rows on demand from a DataFrame.
@@ -77,7 +79,7 @@ function HighTableData(props: PropsData) {
 
   return (
     /* Create a new set of widths if the data has changed, but keep it if only the number of rows changed */
-    <ColumnStatesProvider key={cacheKey ?? key} localStorageKey={cacheKey ? `${cacheKey}${columnStatesSuffix}` : undefined} numColumns={data.header.length} minWidth={minWidth}>
+    <ColumnWidthsProvider key={cacheKey ?? key} localStorageKey={cacheKey ? `${cacheKey}${columnWidthsSuffix}` : undefined} numColumns={data.header.length} minWidth={minWidth}>
       {/* Create a new context if the dataframe changes, to flush the cache (ranks and indexes) */}
       <OrderByProvider key={key} orderBy={orderBy} onOrderByChange={onOrderByChange} disabled={!data.sortable}>
         {/* Create a new selection context if the dataframe has changed */}
@@ -90,7 +92,7 @@ function HighTableData(props: PropsData) {
           </CellsNavigationProvider>
         </SelectionProvider>
       </OrderByProvider>
-    </ColumnStatesProvider>
+    </ColumnWidthsProvider>
   )
 }
 
@@ -131,7 +133,7 @@ export function HighTableInner({
   const { numRows } = data
   const { enterCellsNavigation, setEnterCellsNavigation, onTableKeyDown: onNavigationTableKeyDown, onScrollKeyDown, cellPosition, focusFirstCell } = useCellsNavigation()
   const { containerRef } = usePortalContainer()
-  const { setAvailableWidth } = useColumnStates()
+  const { setAvailableWidth } = useColumnWidths()
   const { orderBy, onOrderByChange } = useOrderBy()
   const { selectable, toggleAllRows, pendingSelectionGesture, onTableKeyDown: onSelectionTableKeyDown, allRowsSelected, isRowSelected, toggleRowNumber, toggleRangeToRowNumber } = useSelection()
   const columns = useTableConfig(data, columnConfiguration)

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -19,7 +19,7 @@ export default function TableHeader({
   columnDescriptors, orderBy, onOrderByChange, canMeasureWidth, ariaRowIndex, columnClassNames = [],
 }: TableHeaderProps) {
   // Function to handle click for changing orderBy
-  const getOnOrderByClick = useCallback((columnHeader: string) => {
+  const getToggleOrderBy = useCallback((columnHeader: string) => {
     if (!onOrderByChange || !orderBy) return undefined
     return () => {
       onOrderByChange(toggleColumn(columnHeader, orderBy))
@@ -44,7 +44,7 @@ export default function TableHeader({
         direction={orderByColumn.get(name)?.direction}
         orderByIndex={orderByColumn.get(name)?.index}
         orderBySize={orderBy?.length}
-        onClick={getOnOrderByClick(name)}
+        toggleOrderBy={getToggleOrderBy(name)}
         columnName={name}
         columnIndex={columnIndex}
         className={columnClassNames[columnIndex]}

--- a/src/hooks/useColumnMenu.ts
+++ b/src/hooks/useColumnMenu.ts
@@ -8,8 +8,8 @@ export function useColumnMenu(
   const [isOpen, setIsOpen] = useState(false)
   const menuId = useId()
 
-  const handleToggle = useCallback(() => {
-    setIsOpen((current) => !current)
+  const close = useCallback(() => {
+    setIsOpen(false)
   }, [])
 
   const handleMenuClick = useCallback(
@@ -34,7 +34,7 @@ export function useColumnMenu(
     isOpen,
     position,
     menuId,
-    handleToggle,
+    close,
     handleMenuClick,
   }
 }

--- a/src/hooks/useColumnVisibilityStates.tsx
+++ b/src/hooks/useColumnVisibilityStates.tsx
@@ -57,14 +57,14 @@ export function ColumnVisibilityStatesProvider({ children, localStorageKey, numC
     return columnVisibilityStates?.[columnIndex]?.hidden === true
   }, [columnVisibilityStates])
 
-  const { numberOfVisibleColumns, numberOfHiddenColumns } = useMemo(() => {
-    let numberOfVisibleColumns = 0
+  const { numberOfHiddenColumns, numberOfVisibleColumns } = useMemo(() => {
+    let numberOfHiddenColumns = 0
     for (let i = 0; i < numColumns; i++) {
-      if (!isHiddenColumn(i)) {
-        numberOfVisibleColumns++
+      if (isHiddenColumn(i)) {
+        numberOfHiddenColumns++
       }
     }
-    return { numberOfVisibleColumns, numberOfHiddenColumns: numColumns - numberOfVisibleColumns }
+    return { numberOfHiddenColumns, numberOfVisibleColumns: numColumns - numberOfHiddenColumns }
   }, [numColumns, isHiddenColumn])
 
   const canBeHidden = useCallback((columnIndex: number) => {
@@ -79,7 +79,6 @@ export function ColumnVisibilityStatesProvider({ children, localStorageKey, numC
       setColumnVisibilityStates(columnVisibilityStates => {
         const nextColumnVisibilityStates = [...columnVisibilityStates ?? []]
         nextColumnVisibilityStates[columnIndex] = { hidden: true }
-        console.log({ columnVisibilityStates, nextColumnVisibilityStates, columnIndex })
         return nextColumnVisibilityStates
       })
     }
@@ -90,9 +89,9 @@ export function ColumnVisibilityStatesProvider({ children, localStorageKey, numC
       return undefined
     }
     return () => {
-      setColumnVisibilityStates([...Array(numColumns).fill(undefined)])
+      setColumnVisibilityStates(undefined)
     }
-  }, [numberOfHiddenColumns, setColumnVisibilityStates, numColumns])
+  }, [numberOfHiddenColumns, setColumnVisibilityStates])
 
   const value = useMemo(() => {
     return {

--- a/src/hooks/useColumnVisibilityStates.tsx
+++ b/src/hooks/useColumnVisibilityStates.tsx
@@ -1,0 +1,112 @@
+import { ReactNode, createContext, useCallback, useContext, useMemo } from 'react'
+import { useLocalStorageState } from './useLocalStorageState.js'
+
+interface ColumnVisibilityStatesContextType {
+  getHideColumn?: (columnIndex: number) => undefined | (() => void) // returns a function to hide the column, or undefined if the column cannot be hidden
+  showAllColumns?: () => void // returns a function to show all columns, or undefined if there are no hidden columns
+  isHiddenColumn?: (columnIndex: number) => boolean // returns true if the column is hidden
+}
+
+export const ColumnVisibilityStatesContext = createContext<ColumnVisibilityStatesContextType>({})
+
+interface ColumnVisibilityStatesProviderProps {
+  localStorageKey?: string // optional key to use for local storage (no local storage if not provided)
+  numColumns: number // number of columns (used to initialize the visibility states array)
+  children: ReactNode
+}
+
+export interface HiddenColumn {
+  hidden: true // true if the column is hidden, default is false
+}
+export type MaybeHiddenColumn = HiddenColumn | undefined
+
+export function ColumnVisibilityStatesProvider({ children, localStorageKey, numColumns }: ColumnVisibilityStatesProviderProps) {
+  if (!Number.isInteger(numColumns) || numColumns < 0) {
+    throw new Error(`Invalid numColumns: ${numColumns}. It must be a positive integer.`)
+  }
+
+  // An array of column visibility states
+  // The index is the column rank in the header (0-based)
+  // The array is uninitialized so that we don't have to know the number of columns in advance
+  const [columnVisibilityStates, setColumnVisibilityStates] = useLocalStorageState<MaybeHiddenColumn[]>({ key: localStorageKey, parse, stringify })
+  function stringify(columnVisibilityStates: MaybeHiddenColumn[]) {
+    return JSON.stringify(columnVisibilityStates)
+  }
+  function parse(json: string): MaybeHiddenColumn[] {
+    const columnVisibilityStates = JSON.parse(json)
+    if (!Array.isArray(columnVisibilityStates)) {
+      return []
+    }
+    // only keep the hidden: true fields
+    return columnVisibilityStates.map((columnVisibility: unknown) => {
+      if (columnVisibility === null || columnVisibility === undefined) {
+        return undefined
+      }
+      if (typeof columnVisibility !== 'object' || !('hidden' in columnVisibility) || columnVisibility.hidden !== true) {
+        return undefined
+      }
+      return { hidden: true }
+    })
+  }
+
+  const isValidIndex = useCallback((index: number) => {
+    return Number.isInteger(index) && index >= 0 && index < numColumns
+  }, [numColumns])
+
+  const isHiddenColumn = useCallback((columnIndex: number) => {
+    return columnVisibilityStates?.[columnIndex]?.hidden === true
+  }, [columnVisibilityStates])
+
+  const { numberOfVisibleColumns, numberOfHiddenColumns } = useMemo(() => {
+    let numberOfVisibleColumns = 0
+    for (let i = 0; i < numColumns; i++) {
+      if (!isHiddenColumn(i)) {
+        numberOfVisibleColumns++
+      }
+    }
+    return { numberOfVisibleColumns, numberOfHiddenColumns: numColumns - numberOfVisibleColumns }
+  }, [numColumns, isHiddenColumn])
+
+  const canBeHidden = useCallback((columnIndex: number) => {
+    return !isHiddenColumn(columnIndex) && numberOfVisibleColumns > 1
+  }, [isHiddenColumn, numberOfVisibleColumns])
+
+  const getHideColumn = useCallback((columnIndex: number ) => {
+    if (!isValidIndex(columnIndex) || !canBeHidden(columnIndex)) {
+      return undefined
+    }
+    return () => {
+      setColumnVisibilityStates(columnVisibilityStates => {
+        const nextColumnVisibilityStates = [...columnVisibilityStates ?? []]
+        nextColumnVisibilityStates[columnIndex] = { hidden: true }
+        console.log({ columnVisibilityStates, nextColumnVisibilityStates, columnIndex })
+        return nextColumnVisibilityStates
+      })
+    }
+  }, [canBeHidden, isValidIndex, setColumnVisibilityStates])
+
+  const showAllColumns = useMemo(() => {
+    if (numberOfHiddenColumns === 0) {
+      return undefined
+    }
+    return () => {
+      setColumnVisibilityStates([...Array(numColumns).fill(undefined)])
+    }
+  }, [numberOfHiddenColumns, setColumnVisibilityStates, numColumns])
+
+  const value = useMemo(() => {
+    return {
+      getHideColumn, showAllColumns, isHiddenColumn,
+    }
+  }, [getHideColumn, showAllColumns, isHiddenColumn])
+
+  return (
+    <ColumnVisibilityStatesContext.Provider value={value}>
+      {children}
+    </ColumnVisibilityStatesContext.Provider>
+  )
+}
+
+export function useColumnVisibilityStates() {
+  return useContext(ColumnVisibilityStatesContext)
+}


### PR DESCRIPTION
Fix #3

I reuse part of the work @rembrandtreyes has done in #147 (and I'll take care of adding him as a co-author).

Tasks:

- [x] add the visibility status of each column in the column state (which is persisted in localstorage)
- [x] add a "Hide column" entry to the column menu
- [x] <strike>this entry would be disabled if there is only one column left</strike>. As `disabled` is not focusable, I guess it's better for accessibility and simplicity to remove the entry if there is only one column left.
- [x] if some columns are hidden, add a "Show all columns" entry
- [x] separate these entries from the sorting entry with a horizontal rule
- [x] ensure we can navigate the menu options with the keyboard
- [x] exclude the hidden columns from the fetches (they will still be fetched if needed for the sort)
- [x] decide where to put the focus when a column is removed. Maybe the top left one for simplicity, since it always exists.
- [x] fix tests.
- [x] add tests


https://github.com/user-attachments/assets/1da138f6-e98f-42f7-b702-cff84275ce7c

## Bugs

Unrelated bug spotted while testing:

- the column menu should always be over the table. When opening the menu on the last column, it overflows to the right.

## Question for @platypii 

Should we add two props to control the columns' visibility (columnsVisibility, onColumnsVisibilityChange, or better: columnsState and onColumnsStateChange)?

It might be useful if we want to show which columns are hidden (or their number) elsewhere in the app. In particular, we may find ourselves in a situation where the data is sorted along a hidden column, which can be confusing because 1. it is not immediately apparent without showing all the columns again, and 2. we can no longer entirely control the sort.

If we do so, we could let the app preserve the column states if needed, and we could remove the dependency on localstorage in hightable (see #215)