### PR TITLE
fix hasCompleteRow: allow resizing if all the cells are resolved

### DIFF
--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -316,7 +316,7 @@ export function HighTableInner({
         const cell = data.getCell({ row, column, orderBy })
         return { columnIndex, cell }
       })
-      if (cells.every(({ cell }) => cell?.value !== undefined)) {
+      if (cells.every(({ cell }) => cell !== undefined)) {
         hasCompleteRow = true
       }
       return {


### PR DESCRIPTION
The bug was that if a column has only undefined values, we could never resize the columns. And by chance, it is the case in the storybook default story, which made it easy to spot the issue.

Introduced in https://github.com/hyparam/hightable/pull/208