### PR TITLE
expose a callback to get the list of hidden columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ interface TableProps {
   selection?: Selection; // selection state (if defined, the component selection is controlled by the parent)
   onSelectionChange?: (selection: Selection) => void; // selection change handler
   columnConfiguration?: Record<string, ColumnConfig>; // allows for additional configuration of columns
+  onColumnsVisibilityChange?: (columnVisibilityStates: MaybeHiddenColumn[]) => void; // columns visibility change handler
 }
 ```
 

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -6,7 +6,7 @@ import { OrderBy } from '../../helpers/sort.js'
 import { cellStyle, getClientWidth, getOffsetWidth } from '../../helpers/width.js'
 import { CellsNavigationProvider, useCellsNavigation } from '../../hooks/useCellsNavigation.js'
 import { ColumnWidthsProvider, useColumnWidths } from '../../hooks/useColumnWidths.js'
-import { ColumnVisibilityStatesProvider, useColumnVisibilityStates } from '../../hooks/useColumnVisibilityStates.js'
+import { ColumnVisibilityStatesProvider, type MaybeHiddenColumn, useColumnVisibilityStates } from '../../hooks/useColumnVisibilityStates.js'
 import { DataProvider, useData } from '../../hooks/useData.js'
 import { OrderByProvider, useOrderBy } from '../../hooks/useOrderBy.js'
 import { PortalContainerProvider, usePortalContainer } from '../../hooks/usePortalContainer.js'
@@ -40,6 +40,7 @@ interface Props {
   onOrderByChange?: (orderBy: OrderBy) => void // callback to call when a user interaction changes the order. The interactions are disabled if undefined.
   selection?: Selection // selection and anchor rows, expressed as data indexes (not as indexes in the table). If undefined, the selection is hidden and the interactions are disabled.
   onSelectionChange?: (selection: Selection) => void // callback to call when a user interaction changes the selection. The selection is expressed as data indexes (not as indexes in the table). The interactions are disabled if undefined.
+  onColumnsVisibilityChange?: (columns: MaybeHiddenColumn[]) => void // callback which is called whenever the set of hidden columns changes.
   stringify?: (value: unknown) => string | undefined
   className?: string // additional class names for the component
   columnClassNames?: (string | undefined)[] // list of additional class names for the header and cells of each column. The index in this array corresponds to the column index in columns
@@ -78,13 +79,13 @@ function HighTableData(props: PropsData) {
   const { data, key, version } = useData()
   const { numRows } = data
   // TODO(SL): onError could be in a context, as we might want to use it everywhere
-  const { cacheKey, orderBy, onOrderByChange, selection, onSelectionChange, onError } = props
+  const { cacheKey, orderBy, onOrderByChange, selection, onSelectionChange, onError, onColumnsVisibilityChange } = props
 
   return (
     /* Create a new set of widths if the data has changed, but keep it if only the number of rows changed */
     <ColumnWidthsProvider key={cacheKey ?? key} localStorageKey={cacheKey ? `${cacheKey}${columnWidthsSuffix}` : undefined} numColumns={data.header.length} minWidth={minWidth}>
       {/* Create a new set of hidden columns if the data has changed, but keep it if only the number of rows changed */}
-      <ColumnVisibilityStatesProvider key={cacheKey ?? key} localStorageKey={cacheKey ? `${cacheKey}${columnVisibilityStatesSuffix}` : undefined} numColumns={data.header.length}>
+      <ColumnVisibilityStatesProvider key={cacheKey ?? key} localStorageKey={cacheKey ? `${cacheKey}${columnVisibilityStatesSuffix}` : undefined} numColumns={data.header.length} onColumnsVisibilityChange={onColumnsVisibilityChange}>
         {/* Create a new context if the dataframe changes, to flush the cache (ranks and indexes) */}
         <OrderByProvider key={key} orderBy={orderBy} onOrderByChange={onOrderByChange} disabled={!data.sortable}>
           {/* Create a new selection context if the dataframe has changed */}

--- a/src/hooks/useColumnVisibilityStates.tsx
+++ b/src/hooks/useColumnVisibilityStates.tsx
@@ -12,6 +12,7 @@ export const ColumnVisibilityStatesContext = createContext<ColumnVisibilityState
 interface ColumnVisibilityStatesProviderProps {
   localStorageKey?: string // optional key to use for local storage (no local storage if not provided)
   numColumns: number // number of columns (used to initialize the visibility states array)
+  onColumnsVisibilityChange?: (columns: MaybeHiddenColumn[]) => void // callback which is called whenever the set of hidden columns changes.
   children: ReactNode
 }
 
@@ -20,7 +21,7 @@ export interface HiddenColumn {
 }
 export type MaybeHiddenColumn = HiddenColumn | undefined
 
-export function ColumnVisibilityStatesProvider({ children, localStorageKey, numColumns }: ColumnVisibilityStatesProviderProps) {
+export function ColumnVisibilityStatesProvider({ children, localStorageKey, numColumns, onColumnsVisibilityChange }: ColumnVisibilityStatesProviderProps) {
   if (!Number.isInteger(numColumns) || numColumns < 0) {
     throw new Error(`Invalid numColumns: ${numColumns}. It must be a positive integer.`)
   }
@@ -79,10 +80,11 @@ export function ColumnVisibilityStatesProvider({ children, localStorageKey, numC
       setColumnVisibilityStates(columnVisibilityStates => {
         const nextColumnVisibilityStates = [...columnVisibilityStates ?? []]
         nextColumnVisibilityStates[columnIndex] = { hidden: true }
+        onColumnsVisibilityChange?.(nextColumnVisibilityStates)
         return nextColumnVisibilityStates
       })
     }
-  }, [canBeHidden, isValidIndex, setColumnVisibilityStates])
+  }, [canBeHidden, isValidIndex, setColumnVisibilityStates, onColumnsVisibilityChange])
 
   const showAllColumns = useMemo(() => {
     if (numberOfHiddenColumns === 0) {
@@ -90,8 +92,9 @@ export function ColumnVisibilityStatesProvider({ children, localStorageKey, numC
     }
     return () => {
       setColumnVisibilityStates(undefined)
+      onColumnsVisibilityChange?.([])
     }
-  }, [numberOfHiddenColumns, setColumnVisibilityStates])
+  }, [numberOfHiddenColumns, setColumnVisibilityStates, onColumnsVisibilityChange])
 
   const value = useMemo(() => {
     return {


### PR DESCRIPTION
New prop to HighTable: `onColumnsVisibilityChange`

It is called with an array of `undefined` (visible) or `{visibility: 'hidden'}` if hidden. Note that it does not provide the name of the columns; you can only get the indexes, relative to `data.header`.