### PR TITLE
ignore Shift and Meta keys

### DIFF
--- a/src/components/HighTable/HighTable.test.tsx
+++ b/src/components/HighTable/HighTable.test.tsx
@@ -1206,6 +1206,10 @@ describe('Navigating Hightable with the keyboard', () => {
       ['{End}{End}{End}{End}', rowIndex, lastCol],
       ['{Control>}{Home}{Home}{Home}{Home}{/Control}', firstRow, firstCol],
       // ['{Control>}{End}{End}{End}{End}{/Control}', lastRow, lastCol], // Cannot be tested because it relies on scroll
+
+      // do nothing
+      ['{Shift>}{ArrowLeft}{/Shift}', rowIndex, colIndex], // no op
+      ['{Meta>}{ArrowLeft}{/Meta}', rowIndex, colIndex], // no op
     ])('pressing "%s" moves the focus to the cell (%s, %s)', async (key, expectedRowIndex, expectedColIndex) => {
       const { user } = render(<HighTable data={data} padding={pageSize} />)
       // focus the cell (4, 3)

--- a/src/hooks/useCellsNavigation.tsx
+++ b/src/hooks/useCellsNavigation.tsx
@@ -50,7 +50,13 @@ export function CellsNavigationProvider({ colCount, rowCount, rowPadding, childr
 
   const onTableKeyDown = useCallback((event: KeyboardEvent) => {
     const { key } = event
-    const ctrl = event.ctrlKey || event.metaKey
+    const ctrl = event.ctrlKey
+    const meta = event.metaKey
+    const shift = event.shiftKey
+    // if the user is pressing Meta or Shift, do not handle the event
+    if (meta || shift) {
+      return
+    }
     if (key === 'ArrowRight') {
       if (ctrl) {
         setColIndex(colCount)


### PR DESCRIPTION
fixes #263

---

Bug by me: I thought that Meta was the same as Ctrl on MacOS...