### PR TITLE
Fix css details

### DIFF
--- a/src/HighTable.module.css
+++ b/src/HighTable.module.css
@@ -221,6 +221,7 @@
   --accent-background-color-3: #fbf7bf;
   --background-color-5: #fff;
   --background-color: var(--background-color-5);
+  --accent-background-color-6: #9d9cd5;
   --focus-background-color: var(--accent-background-color-1); /* keep --focus-background-color for compatibility */
   --focusable-background-color: var(--background-color-1); /* keep --focusable-background-color for compatibility */
   --header-background-color: var(--background-color-1);
@@ -236,6 +237,7 @@
   --row-hovered-background-color: var(--accent-background-color-2);
   --row-selected-background-color: var(--accent-background-color-3);
   --corner-cell-background-color: var(--background-color-4);
+  --resize-indicator-background-color: var(--accent-background-color-6);
 
   --cell-busy-background: linear-gradient(
       60deg,
@@ -326,7 +328,7 @@
         width: 4px;
         height: 4px;
         border-radius: 50%;
-        background-color: var(--top-border-color);
+        background-color: var(--resize-indicator-background-color);
         content: "";
       }
     }


### PR DESCRIPTION
In particular, more precise and discrete resizer. Also, the resize indicator (the small dot) does not overlap anymore with the menu button)

before:

<img width="640" height="400" alt="Screenshot From 2025-09-23 18-11-31" src="https://github.com/user-attachments/assets/a53c14e9-599a-4a1d-8b85-47d964b9ee03" />

after:

<img width="640" height="400" alt="Screenshot From 2025-09-23 18-11-10" src="https://github.com/user-attachments/assets/ab8c15f8-118a-4ec3-acf2-4a6fc42bbecb" />
