### PR TITLE
opening up event fowarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hightable",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "A dynamic windowed scrolling table component for react",
   "author": "Hyperparam",
   "homepage": "https://hyperparam.app",

--- a/src/helpers/dataframe/filter.ts
+++ b/src/helpers/dataframe/filter.ts
@@ -46,25 +46,25 @@ export function filterDataFrame<M extends Obj, C extends Obj>(
 
   if (upstreamFetch !== undefined) {
     const eventTarget = createEventTarget<DataFrameEvents>()
+
+    // Set up persistent event forwarding from upstream dataframe
+    if (data.eventTarget) {
+      data.eventTarget.addEventListener('resolve', () => {
+        eventTarget.dispatchEvent(new CustomEvent('resolve'))
+      })
+    }
+
     const fetch: Fetch = async function({ rowStart, rowEnd, columns, orderBy, signal }: { rowStart: number, rowEnd: number, columns?: string[], orderBy?: OrderBy, signal?: AbortSignal }) {
       validateFetchParams({ rowStart, rowEnd, columns, orderBy, data: { numRows, columnDescriptors } })
       checkSignal(signal)
 
-      function callback() {
+      // The upstream rows are ordered, so we can fetch them by continuous ranges.
+      const ranges = getContinuousRanges(upstreamRows.slice(rowStart, rowEnd))
+      const promises = ranges.map((range) => upstreamFetch({ ...range, columns, signal }).then(() => {
+        checkSignal(signal)
         eventTarget.dispatchEvent(new CustomEvent('resolve'))
-      }
-      try {
-        data.eventTarget?.addEventListener('resolve', callback)
-        // The upstream rows are ordered, so we can fetch them by continuous ranges.
-        const ranges = getContinuousRanges(upstreamRows.slice(rowStart, rowEnd))
-        const promises = ranges.map((range) => upstreamFetch({ ...range, columns, signal }).then(() => {
-          checkSignal(signal)
-          eventTarget.dispatchEvent(new CustomEvent('resolve'))
-        }))
-        await Promise.all(promises)
-      } finally {
-        data.eventTarget?.removeEventListener('resolve', callback)
-      }
+      }))
+      await Promise.all(promises)
     }
     df.eventTarget = eventTarget
     df.fetch = fetch


### PR DESCRIPTION
This change unrestricts the event forwarding for sortableDataFrame and filterableDataFrame. Currently, both of these only forward events while the fetch function is active meaning that other non synchronous methods for fetching and populating the cache can be problematic.

This change should be fully backwards compatible.