### PR TITLE
Don't show unneeded horizontal scrollbar

### DIFF
--- a/src/HighTable.module.css
+++ b/src/HighTable.module.css
@@ -16,7 +16,6 @@
   .table-scroll {
     flex: 1;
     overflow: auto;
-    scrollbar-gutter: stable both-edges;
     & > div {
       position: relative;
     }

--- a/src/hooks/useColumnWidths.tsx
+++ b/src/hooks/useColumnWidths.tsx
@@ -7,6 +7,7 @@ const defaultMinWidth = 50 // minimum width of a cell in px, used to compute the
 const snapDistance = 10 // if a small space remains to the right of the last column after shrinking widths, it's filled by expanding some columns
 const maxAdjustmentRatio = 3 // when adjusting, we don't want to shrink a column too much. It's the maximum ratio between the measured width and the adjusted width
 const minAdjustedWidth = 150 // when adjusting, we don't want to shrink a column too much. It's the minimum adjusted width
+const underfillMargin = 3 // leave 3px unused to avoid showing an unneeded horizontal scrollbar
 // TODO(SL): let config.minAdjustedWidth override minAdjustedWidth the same way config.minWidth does for minWidth?
 
 /**
@@ -261,7 +262,8 @@ function adjustWidths({
     const columnWidth = fixedWidths?.[columnIndex] ?? measuredWidths[columnIndex] ?? getMinWidth(columnIndex)
     totalWidth += columnWidth
   }
-  let excedent = totalWidth - maxTotalWidth
+  // Target slightly less than available to avoid triggering an unneeded scrollbar
+  let excedent = totalWidth - Math.max(0, maxTotalWidth - underfillMargin)
 
   if (excedent <= 0) {
     return []


### PR DESCRIPTION
Certain sets of columns at certain widths can show a persistent horizontal scrollbar that takes up 99% of the horizontal space. This is because the total widths of all of the columns can sometimes be slightly larger than than the totalWidth. A small margin prevents the scrollbar from staying on the screen. Note that the scrollbar will still appear temporarily when you reduce the size of the window, that is because the widow size must change first and the column widths are adjusted after the fact. However with this change it should be impossible to find a width where the scrollbar will persist on screen, unless you have actually reduced the table width below the minimum width of all columns.