### PR TITLE
columnClassNames in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ interface TableProps {
   data: DataFrame // data provider for the table
   cacheKey?: string // used to persist column widths. If undefined, the column widths are not persisted. It is expected to be unique for each table.
   className?: string // additional class name for the table container
-  columnClassNames?: (string | undefined)[] // list of additional class names for the header and cells of each column. The index in this array corresponds to the column index in columns
   columnConfiguration?: Record<string, ColumnConfig> // allows for additional configuration of columns
   focus?: boolean // focus table on mount? (default true)
   maxRowNumber?: number // maximum row number to display (for row headers). Useful for filtered data. If undefined, the number of rows in the data frame is applied.
@@ -178,6 +177,8 @@ ColumnConfig is defined as:
 interface ColumnConfig {
   headerComponent?: React.ReactNode // allows overriding column header cell with custom component
   minWidth?: number // overrides the global column min width, useful for components with ui elements
+  initiallyHidden?: boolean // whether the column should be initially hidden
+  className?: string // additional CSS class name for the header and cells of this column
 }
 ```
 

--- a/src/components/HighTable/HighTable.stories.tsx
+++ b/src/components/HighTable/HighTable.stories.tsx
@@ -298,7 +298,11 @@ export const CustomHeaderStyle: Story = {
     //   background-color: #ffe9a9;
     // }
     className: 'custom-hightable',
-    columnClassNames: [undefined, undefined, 'delegated'],
+    columnConfiguration: {
+      Double: {
+        className: 'delegated',
+      },
+    },
   },
 }
 export const HeaderComponent: Story = {

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -27,7 +27,6 @@ interface Props {
   data: DataFrame
   cacheKey?: string // used to persist column widths. If undefined, the column widths are not persisted. It is expected to be unique for each table.
   className?: string // additional class names for the component
-  columnClassNames?: (string | undefined)[] // list of additional class names for the header and cells of each column. The index in this array corresponds to the column index in columns
   columnConfiguration?: ColumnConfiguration
   focus?: boolean // focus table on mount? (default true)
   maxRowNumber?: number // maximum row number to display (for row headers). Useful for filtered data. If undefined, the number of rows in the data frame is applied.
@@ -141,7 +140,6 @@ export function HighTableInner({
   onError = console.error,
   stringify = stringifyDefault,
   className = '',
-  columnClassNames = [],
   styled = true,
   version,
   renderCellContent,
@@ -400,7 +398,6 @@ export function HighTableInner({
                   columnsParameters={columnsParameters}
                   orderBy={orderBy}
                   onOrderByChange={onOrderByChange}
-                  columnClassNames={columnClassNames}
                   ariaRowIndex={1}
                 />
               </Row>
@@ -436,6 +433,7 @@ export function HighTableInner({
                       ariaRowIndex={ariaRowIndex}
                     />
                     {cells.map(({ columnIndex, cell }) => {
+                      const columnClassName = columnsParameters[columnIndex]?.className
                       return <Cell
                         key={columnIndex}
                         onDoubleClickCell={onDoubleClickCell}
@@ -443,7 +441,7 @@ export function HighTableInner({
                         onKeyDownCell={onKeyDownCell}
                         stringify={stringify}
                         columnIndex={columnIndex}
-                        className={columnClassNames[columnIndex]}
+                        className={columnClassName}
                         ariaColIndex={columnIndex + ariaOffset}
                         ariaRowIndex={ariaRowIndex}
                         cell={cell}

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -10,14 +10,13 @@ interface TableHeaderProps {
   onOrderByChange?: (orderBy: OrderBy) => void // callback to call when a user interaction changes the order. The interactions are disabled if undefined.
   canMeasureColumn?: Record<string, boolean> // indicates if the width of a column can be measured.
   ariaRowIndex: number // aria row index for the header
-  columnClassNames?: (string | undefined)[] // array of class names for each column
 }
 
 /**
  * Render a header for a table.
  */
 export default function TableHeader({
-  columnsParameters, orderBy, onOrderByChange, canMeasureColumn, ariaRowIndex, columnClassNames = [],
+  columnsParameters, orderBy, onOrderByChange, canMeasureColumn, ariaRowIndex,
 }: TableHeaderProps) {
   const { data } = useData()
   const exclusiveSort = data.exclusiveSort === true
@@ -35,7 +34,7 @@ export default function TableHeader({
   }, [orderBy])
 
   return columnsParameters.map((columnParameters) => {
-    const { name, index: columnIndex, ...columnConfig } = columnParameters
+    const { name, index: columnIndex, className, ...columnConfig } = columnParameters
     // Note: columnIndex is the index of the column in the dataframe header
     // and not the index of the column in the table (which can be different if
     // some columns are hidden, or if the order is changed)
@@ -51,7 +50,7 @@ export default function TableHeader({
         toggleOrderBy={getToggleOrderBy(name)}
         columnName={name}
         columnIndex={columnIndex}
-        className={columnClassNames[columnIndex]}
+        className={className}
         ariaColIndex={ariaColIndex}
         ariaRowIndex={ariaRowIndex}
         columnConfig={columnConfig}

--- a/src/helpers/columnConfiguration.ts
+++ b/src/helpers/columnConfiguration.ts
@@ -8,6 +8,7 @@ export interface ColumnConfig {
   headerComponent?: HeaderComponent;
   minWidth?: number;
   initiallyHidden?: boolean;
+  className?: string;
   // hideable?: boolean;
   // filters: Some filter structure
   // cellRenderer?: (value: unknown, row: Row) => React.ReactNode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import HighTable from './components/HighTable/HighTable.js'
 export { type CellContentProps } from './components/HighTable/HighTable.js'
+export type { ColumnConfig, ColumnConfiguration } from './helpers/columnConfiguration.js'
 export { arrayDataFrame, checkSignal, convertV1ToDataFrame, createGetRowNumber, filterDataFrame, sortableDataFrame, validateColumn, validateFetchParams, validateGetCellParams, validateGetRowNumberParams, validateOrderBy, validateRow } from './helpers/dataframe/index.js'
 export type { Cells, DataFrame, DataFrameEvents, ResolvedValue } from './helpers/dataframe/index.js'
 export { resolvablePromise, wrapPromise, wrapResolved } from './helpers/dataframe/legacy/promise.js'


### PR DESCRIPTION
This is a breaking change, custom class names will go into the column config, instead of into the table directly.

Fixes https://github.com/hyparam/hightable/issues/325