### PR TITLE
Restore deleted styles

### DIFF
--- a/src/HighTable.module.css
+++ b/src/HighTable.module.css
@@ -408,8 +408,8 @@
   /* cells */
   th,
   td {
-    border-bottom: 1px solid var(--cell-border-color);
-    border-right: 1px solid var(--cell-border-color);
+    border-bottom: var(--cell-border-width) solid var(--cell-border-color);
+    border-right: var(--cell-border-width) solid var(--cell-border-color);
     height: 32px;
     line-height: 1.5;
     /* prevent columns expanding - limits the initial and autoresized width */
@@ -555,8 +555,8 @@
     background-color: var(--row-number-background-color);
     border-right: 1px solid var(--row-number-right-border-color);
     color: var(--row-number-color);
-    font-size: 0.68rem;
-    padding: 0 2px;
+    padding: 0;
+    font-size: var(--row-number-font-size);
     text-align: center;
   }
   /* highlight the selected rows */


### PR DESCRIPTION
This PR https://github.com/hyparam/hightable/pull/321 made some changes to HighTable.module.css based off an older commit from master and accidentally deleted a bunch of changes from https://github.com/hyparam/hightable/pull/316. This should restore all the changes made by that PR