### PR TITLE
Styles for tall headers

### DIFF
--- a/.storybook/global.css
+++ b/.storybook/global.css
@@ -99,3 +99,6 @@ h6 {
 .custom-hightable tbody tr:not(:hover) td.delegated {
   background-color: #ffe9a9;
 }
+.custom-hightable thead th.tall {
+  height: 80px;
+}

--- a/src/HighTable.module.css
+++ b/src/HighTable.module.css
@@ -381,7 +381,8 @@
   /* Default headers: sort arrow positioning and coloring */
   th[aria-sort]::after {
     right: calc(var(--cell-horizontal-padding) + 1rem);
-    top: 4px;
+    top: 50%;
+    transform: translateY(-50%);
     padding-left: 2px;
     background: none;
     color: var(--secondary-sort-icon-color);

--- a/src/components/HighTable/HighTable.stories.tsx
+++ b/src/components/HighTable/HighTable.stories.tsx
@@ -290,6 +290,17 @@ export const MultiSort: Story = {
     data: sortableDataFrame(createUnsortableData()),
   },
 }
+export const CustomTallHeaderStyle: Story = {
+  args: {
+    data: sortableDataFrame(createUnsortableData()),
+    className: 'custom-hightable',
+    columnConfiguration: {
+      Double: {
+        className: 'tall',
+      },
+    },
+  },
+}
 export const CustomHeaderStyle: Story = {
   args: {
     data: createUnsortableData(),


### PR DESCRIPTION
Keep the styles looking ok no matter how tall the headers are. Vertically center the sort icon instead of giving it a fixed margin.