### PR TITLE
[refactor] less rerenders, by swapping two providers

### DIFF
--- a/src/components/HighTable/Slice.tsx
+++ b/src/components/HighTable/Slice.tsx
@@ -42,8 +42,8 @@ export default function Slice({
   const { rowIndex, colCount, rowCount, setColIndex, setRowIndex, setShouldFocus } = useContext(CellNavigationContext)
   const { orderBy, onOrderByChange } = useContext(OrderByContext)
   const { selectable, toggleAllRows, pendingSelectionGesture, onTableKeyDown: onSelectionTableKeyDown, allRowsSelected, isRowSelected, toggleRowNumber, toggleRangeToRowNumber } = useContext(SelectionContext)
-  const { columnsParameters, renderedRowsRange } = useContext(RowsAndColumnsContext)
-  const { scrollRowIntoView } = useContext(ScrollModeContext)
+  const { columnsParameters } = useContext(RowsAndColumnsContext)
+  const { scrollRowIntoView, renderedRowsRange } = useContext(ScrollModeContext)
 
   // TODO(SL): we depend on rowIndex to trigger the scroll effect, which means we recreate the
   // callback every time the rowIndex changes. Can we avoid that?

--- a/src/components/HighTable/Wrapper.tsx
+++ b/src/components/HighTable/Wrapper.tsx
@@ -17,6 +17,7 @@ import { ColumnWidthsProvider } from '../../providers/ColumnWidthsProvider.js'
 import { OrderByProvider } from '../../providers/OrderByProvider.js'
 import type { RowsAndColumnsProviderProps } from '../../providers/RowsAndColumnsProvider.js'
 import { RowsAndColumnsProvider } from '../../providers/RowsAndColumnsProvider.js'
+import type { ScrollModeProviderProps } from '../../providers/ScrollModeProvider.js'
 import { ScrollModeProvider } from '../../providers/ScrollModeProvider.js'
 import { SelectionProvider } from '../../providers/SelectionProvider.js'
 import Scroller from './Scroller.js'
@@ -33,7 +34,7 @@ export type WrapperProps = {
   onColumnsVisibilityChange?: (columns: Record<string, MaybeHiddenColumn>) => void // callback which is called whenever the set of hidden columns changes.
   onOrderByChange?: (orderBy: OrderBy) => void // callback to call when a user interaction changes the order. The interactions are disabled if undefined.
   onSelectionChange?: (selection: Selection) => void // callback to call when a user interaction changes the selection. The selection is expressed as data indexes (not as indexes in the table). The interactions are disabled if undefined.
-} & RowsAndColumnsProviderProps & CellNavigationProviderProps & SliceProps
+} & RowsAndColumnsProviderProps & CellNavigationProviderProps & ScrollModeProviderProps & SliceProps
 
 export default function Wrapper({
   columnConfiguration,
@@ -101,18 +102,18 @@ export default function Wrapper({
                 <SelectionProvider key={key} selection={selection} onSelectionChange={onSelectionChange} data={data} numRows={numRows}>
                   {/* Create a new navigation context if the dataframe has changed, because the focused cell might not exist anymore */}
                   <CellNavigationProvider key={key} focus={focus}>
-                    <RowsAndColumnsProvider key={key} padding={padding} overscan={overscan}>
-                      <ScrollModeProvider numRows={numRows} headerHeight={headerHeight}>
+                    <ScrollModeProvider numRows={numRows} headerHeight={headerHeight} padding={padding}>
+                      <Scroller setViewportWidth={setViewportWidth}>
 
-                        <Scroller setViewportWidth={setViewportWidth}>
+                        <RowsAndColumnsProvider key={key} overscan={overscan}>
                           <Slice
                             setTableCornerSize={setTableCornerSize}
                             {...rest}
                           />
-                        </Scroller>
+                        </RowsAndColumnsProvider>
 
-                      </ScrollModeProvider>
-                    </RowsAndColumnsProvider>
+                      </Scroller>
+                    </ScrollModeProvider>
                   </CellNavigationProvider>
                 </SelectionProvider>
               </OrderByProvider>

--- a/src/contexts/RowsAndColumnsContext.ts
+++ b/src/contexts/RowsAndColumnsContext.ts
@@ -2,16 +2,8 @@ import { createContext } from 'react'
 
 import type { ColumnParameters } from '../contexts/ColumnParametersContext.js'
 
-export interface RowsRange {
-  start: number // first row index (inclusive). Indexes refer to the virtual table domain.
-  end: number // last row index (exclusive)
-}
-
 interface RowsAndColumnsContextType {
   columnsParameters?: ColumnParameters[]
-  visibleRowsRange?: RowsRange // range of rows visible in the viewport
-  renderedRowsRange?: RowsRange // range of rows rendered in the DOM as table rows (including padding and overscan)
-  setVisibleRowsRange?: (rowsRange: RowsRange | undefined) => void
 }
 
 export const defaultRowsAndColumnsContext: RowsAndColumnsContextType = {}

--- a/src/contexts/ScrollModeContext.ts
+++ b/src/contexts/ScrollModeContext.ts
@@ -1,9 +1,16 @@
 import { createContext } from 'react'
 
+export interface RowsRange {
+  start: number // first row index (inclusive). Indexes refer to the virtual table domain.
+  end: number // last row index (exclusive)
+}
+
 export interface ScrollModeContextType {
   scrollMode?: 'native' | 'virtual'
   canvasHeight?: number // total scrollable height
   sliceTop?: number // offset of the top of the slice from the top of the canvas
+  renderedRowsRange?: RowsRange // range of rows rendered in the DOM as table rows (including padding rows)
+  visibleRowsRange?: RowsRange // range of rows visible in the viewport
   onViewportChange?: (viewport: { clientHeight: number, scrollTop: number }) => void // function to call when the current viewport height and scroll top position change
   scrollRowIntoView?: ({ rowIndex }: { rowIndex: number }) => void // function to scroll so that the row is visible in the table
   setScrollTo?: (scrollTo: HTMLElement['scrollTo'] | undefined) => void // function to set the scrollTo function

--- a/src/providers/ScrollModeProvider.tsx
+++ b/src/providers/ScrollModeProvider.tsx
@@ -1,17 +1,21 @@
 import type { ReactNode } from 'react'
 import { useMemo } from 'react'
 
-import { maxElementHeight, rowHeight } from '../helpers/constants.js'
+import { defaultPadding, maxElementHeight, rowHeight } from '../helpers/constants.js'
 import { ScrollModeNativeProvider } from './ScrollModeNativeProvider.js'
 import { ScrollModeVirtualProvider } from './ScrollModeVirtualProvider.js'
 
-interface ScrollModeProviderProps {
+export interface ScrollModeProviderProps {
+  padding?: number // number of rows to render beyond the visible table cells
+}
+
+type Props = {
   children: ReactNode
   headerHeight: number // height of the table header
   numRows: number
-}
+} & ScrollModeProviderProps
 
-export function ScrollModeProvider({ children, headerHeight, numRows }: ScrollModeProviderProps) {
+export function ScrollModeProvider({ children, headerHeight, numRows, padding = defaultPadding }: Props) {
   // total table height - it's fixed, based on the number of rows.
   // if the number of rows is big, this value can overflow the maximum height supported by the browser.
   // If so, we switch to the 'virtual scroll' mode, where we override the scrolling mechanism.
@@ -19,7 +23,7 @@ export function ScrollModeProvider({ children, headerHeight, numRows }: ScrollMo
 
   if (tableHeight < maxElementHeight) {
     return (
-      <ScrollModeNativeProvider canvasHeight={tableHeight} numRows={numRows}>
+      <ScrollModeNativeProvider canvasHeight={tableHeight} numRows={numRows} padding={padding}>
         {children}
       </ScrollModeNativeProvider>
     )


### PR DESCRIPTION
ScrollModeProvider is in charge of computing the visible rows, while RowsAndColumnsProvider will only fetch the required cells

This refactoring should reduce the number of rerenders