### PR TITLE
[refactor] don't call scrollTo in native mode

### DIFF
--- a/src/hooks/useCellFocus.ts
+++ b/src/hooks/useCellFocus.ts
@@ -25,14 +25,18 @@ export function useCellFocus({ ariaColIndex, ariaRowIndex }: CellData): CellFocu
     if (!element || !isCurrentCell || !shouldFocus || isScrolling) {
       return
     }
-    // scroll the cell into view
+    // scroll the cell into view (vertically and horizontally) and focus it
     //
     // scroll-padding-inline-start and scroll-padding-block-start are set in the CSS
     // to avoid the cell being hidden by the row and column headers
     //
-    // Note that it might scroll both vertically and horizontally.
+    // we don't use the simpler form:
+    //   element.focus()
+    // due to its default scroll behavior. After focusing the elements, it scrolls it into view using `block: center' and
+    // `inline: center`. But `block: nearest` and `inline: nearest` feel more natural for navigation. So, we use
+    // scrollIntoView first, then focus with `preventScroll: true`.
     element.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' })
-    element.focus()
+    element.focus({ preventScroll: true })
     setShouldFocus(false)
   }, [isCurrentCell, shouldFocus, setShouldFocus, isScrolling])
 

--- a/src/providers/ScrollModeProvider.tsx
+++ b/src/providers/ScrollModeProvider.tsx
@@ -23,7 +23,7 @@ export function ScrollModeProvider({ children, headerHeight, numRows, padding = 
 
   if (tableHeight < maxElementHeight) {
     return (
-      <ScrollModeNativeProvider canvasHeight={tableHeight} numRows={numRows} padding={padding}>
+      <ScrollModeNativeProvider canvasHeight={tableHeight} numRows={numRows} headerHeight={headerHeight} padding={padding}>
         {children}
       </ScrollModeNativeProvider>
     )


### PR DESCRIPTION
We already scroll to the current cell using scrollIntoView() when focusing it. No need to do the job twice.

On the contrary, when using the virtual scroll, we need to operate in two steps:
1. scroll vertically to the low-precision scrollTop, so that the current row is in the viewport
2. once done (`isScrolling === false`), we use scrollIntoView to scroll horizontally

We cannot use scrollIntoView for point 1.  because the new scrollTop would not be aligned with the computed state.