### PR TITLE
Jump to row command

### DIFF
--- a/src/components/HighTable/HighTable.stories.tsx
+++ b/src/components/HighTable/HighTable.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { MouseEvent, ReactNode } from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { checkSignal, createGetRowNumber, validateFetchParams, validateGetCellParams } from '../../helpers/dataframe/helpers.js'
 import type { DataFrame, DataFrameEvents } from '../../helpers/dataframe/index.js'
@@ -9,8 +9,9 @@ import { sortableDataFrame } from '../../helpers/dataframe/sort.js'
 import type { Fetch, ResolvedValue } from '../../helpers/dataframe/types.js'
 import type { Selection } from '../../helpers/selection.js'
 import type { OrderBy } from '../../helpers/sort.js'
-import { createEventTarget } from '../../helpers/typedEventTarget.js'
+import { createEventTarget, TypedCustomEvent } from '../../helpers/typedEventTarget.js'
 import type { CellContentProps } from '../Cell/Cell.js'
+import type { HighTableCommands } from './HighTable.js'
 import HighTable from './HighTable.js'
 
 function random(seed: number) {
@@ -639,5 +640,25 @@ export const LargeData: Story = {
 export const SmallData: Story = {
   args: {
     data: createSmallData(),
+  },
+}
+
+export const JumpToRow: Story = {
+  render: () => {
+    const commands = useMemo(() => createEventTarget<HighTableCommands>(), [])
+    function jumpTo(row: number) {
+      commands.dispatchEvent(new TypedCustomEvent('scrollRowIntoView', { detail: row }))
+    }
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: 10 }}>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button type="button" onClick={() => { jumpTo(1) }}>Row 1</button>
+          <button type="button" onClick={() => { jumpTo(500) }}>Row 500</button>
+          <button type="button" onClick={() => { jumpTo(1000) }}>Row 1000</button>
+        </div>
+        <HighTable data={createUnsortableData()} commands={commands} />
+      </div>
+    )
   },
 }

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -4,6 +4,10 @@ import { DataProvider } from '../../providers/DataProvider.js'
 import type { WrapperProps } from './Wrapper.js'
 import Wrapper from './Wrapper.js'
 
+export interface HighTableCommands {
+  scrollRowIntoView: number // 1-indexed row number
+}
+
 type Props = {
   data: DataFrame
   maxRowNumber?: number // maximum row number to display (for row headers). Useful for filtered data. If undefined, the number of rows in the data frame is applied.

--- a/src/components/HighTable/Wrapper.tsx
+++ b/src/components/HighTable/Wrapper.tsx
@@ -40,6 +40,7 @@ export default function Wrapper({
   columnConfiguration,
   cacheKey,
   className = '',
+  commands,
   focus,
   orderBy,
   padding,
@@ -102,7 +103,7 @@ export default function Wrapper({
                 <SelectionProvider key={key} selection={selection} onSelectionChange={onSelectionChange} data={data} numRows={numRows}>
                   {/* Create a new navigation context if the dataframe has changed, because the focused cell might not exist anymore */}
                   <CellNavigationProvider key={key} focus={focus}>
-                    <ScrollProvider numRows={numRows} headerHeight={headerHeight} padding={padding}>
+                    <ScrollProvider commands={commands} numRows={numRows} headerHeight={headerHeight} padding={padding}>
                       <Scroller setViewportWidth={setViewportWidth}>
 
                         <RowsAndColumnsProvider key={key} overscan={overscan}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import HighTable from './components/HighTable/HighTable.js'
+import HighTable, { type HighTableCommands } from './components/HighTable/HighTable.js'
 export { type CellContentProps } from './components/Cell/Cell.js'
 export type { ColumnConfig, ColumnConfiguration } from './helpers/columnConfiguration.js'
 export type { Cells, DataFrame, DataFrameEvents, ResolvedValue } from './helpers/dataframe/index.js'
@@ -9,4 +9,5 @@ export type { CustomEventTarget, TypedCustomEvent } from './helpers/typedEventTa
 export { createEventTarget } from './helpers/typedEventTarget.js'
 export { stringify } from './utils/stringify.js'
 export { HighTable }
+export type { HighTableCommands }
 export default HighTable


### PR DESCRIPTION
Here's my problem... I want the model to call a tool to say "scroll row 10,000 into view" from outside of HighTable.

React does not make this particularly easy. Here's the solution I came up with:

This PR adds a `commands` arg to HighTable that currently includes one `CustomEventTarget` for `scrollRowIntoView` with row index.

Internally, if provided, this gets subscribed to inside the ScrollProvider and then if a `scrollRowIntoView` event is fired, it scrolls to that row.

Open to suggestions on better patterns here @severo  