### PR TITLE
[refactor] validate the cell values when setting the cell

### DIFF
--- a/src/components/HighTable/Slice.tsx
+++ b/src/components/HighTable/Slice.tsx
@@ -61,25 +61,25 @@ export default function Slice({
       if (ctrlKey) {
         colIndex = colCount
       } else {
-        colIndex += 1
+        colIndex = colIndex < colCount ? colIndex + 1 : colCount
       }
     } else if (key === 'ArrowLeft') {
       if (ctrlKey) {
         colIndex = 1
       } else {
-        colIndex -= 1
+        colIndex = colIndex > 1 ? colIndex - 1 : 1
       }
     } else if (key === 'ArrowDown') {
       if (ctrlKey) {
         rowIndex = rowCount
       } else {
-        rowIndex += 1
+        rowIndex = rowIndex < rowCount ? rowIndex + 1 : rowCount
       }
     } else if (key === 'ArrowUp') {
       if (ctrlKey) {
         rowIndex = 1
       } else {
-        rowIndex -= 1
+        rowIndex = rowIndex > 1 ? rowIndex - 1 : 1
       }
     } else if (key === 'Home') {
       if (ctrlKey) {
@@ -92,10 +92,10 @@ export default function Slice({
       }
       colIndex = colCount
     } else if (key === 'PageDown') {
-      rowIndex += numRowsPerPage
+      rowIndex = Math.min(rowIndex + numRowsPerPage, rowCount)
       // TODO(SL): same for horizontal scrolling with Alt+PageDown?
     } else if (key === 'PageUp') {
-      rowIndex -= numRowsPerPage
+      rowIndex = Math.max(rowIndex - numRowsPerPage, 1)
       // TODO(SL): same for horizontal scrolling with Alt+PageUp?
     } else if (key !== ' ') {
       // if the key is not one of the above, do not handle it

--- a/src/providers/CellNavigationProvider.tsx
+++ b/src/providers/CellNavigationProvider.tsx
@@ -34,15 +34,12 @@ export function CellNavigationProvider({ children, focus = true }: Props) {
   const colCount = useMemo(() => numDataColumns + 1, [numDataColumns])
   const [previousColCount, setPreviousColCount] = useState(colCount)
 
-  const goToCell = useCallback((value: Cell) => {
-    const colIndex = Math.min(Math.max(1, value.colIndex), colCount)
-    const rowIndex = Math.min(Math.max(1, value.rowIndex), rowCount)
-
-    setCell({ colIndex, rowIndex })
-    scrollRowIntoView?.({ rowIndex })
+  const goToCell = useCallback((cell: Cell) => {
+    setCell(cell)
+    scrollRowIntoView?.({ rowIndex: cell.rowIndex })
     // after scrolling, focus the cell (and scroll horizontally into view if needed - see focusCurrentCell)
     setShouldFocus(true)
-  }, [scrollRowIntoView, colCount, rowCount])
+  }, [scrollRowIntoView])
 
   // Reset the cell position if the number of rows has decreased and the current row index is out of bounds
   if (rowCount !== previousRowCount) {


### PR DESCRIPTION
Restoring the tests on colCount and rowCount when navigating with the keyboard. This way, we use the cell input, without creating a new object.