### PR TITLE
[refactor] extract scrollAndFocusCell

### DIFF
--- a/src/components/HighTable/Scroller.tsx
+++ b/src/components/HighTable/Scroller.tsx
@@ -14,7 +14,7 @@ export default function Scroller({
   children,
   setViewportWidth,
 }: Props) {
-  const { goToCurrentCell } = useContext(CellNavigationContext)
+  const { scrollAndFocusCurrentCell } = useContext(CellNavigationContext)
   const { canvasHeight, sliceTop, setClientHeight, setScrollTop, setScrollTo } = useContext(ScrollContext)
 
   /**
@@ -32,9 +32,9 @@ export default function Scroller({
     if ((key === 'Tab' && !event.shiftKey) || key === 'Enter' || key === ' ') {
       event.stopPropagation()
       event.preventDefault()
-      goToCurrentCell()
+      scrollAndFocusCurrentCell()
     }
-  }, [goToCurrentCell])
+  }, [scrollAndFocusCurrentCell])
 
   /**
    * Track viewport size and scroll position

--- a/src/contexts/CellNavigationContext.ts
+++ b/src/contexts/CellNavigationContext.ts
@@ -11,8 +11,8 @@ interface CellNavigationContextType {
   rowCount: number // total number of rows in the table
   focusCurrentCell?: (element: HTMLElement) => void // function to focus the current cell, if needed
   goToCell: (value: Cell) => void // function to go to cell. If out of bounds, it is clamped. It scrolls to and focuses the cell, even if the values are unchanged.
-  goToCurrentCell: () => void // function to go to the current cell (navigation state).
   goToFirstCell: () => void // function to go to the first cell (1, 1)
+  scrollAndFocusCurrentCell: () => void // function to scroll to, and focus, the current cell (navigation state).
 }
 
 // the default context assumes a one-cell table (the top left corner is always present)
@@ -22,8 +22,8 @@ export const defaultCellNavigationContext: CellNavigationContextType = {
   rowCount: 1,
   focusCurrentCell: undefined,
   goToCell: () => { /* no-op */ },
-  goToCurrentCell: () => { /* no-op */ },
   goToFirstCell: () => { /* no-op */ },
+  scrollAndFocusCurrentCell: () => { /* no-op */ },
 }
 
 export const CellNavigationContext = createContext<CellNavigationContextType>(defaultCellNavigationContext)

--- a/src/providers/CellNavigationProvider.tsx
+++ b/src/providers/CellNavigationProvider.tsx
@@ -34,12 +34,16 @@ export function CellNavigationProvider({ children, focus = true }: Props) {
   const colCount = useMemo(() => numDataColumns + 1, [numDataColumns])
   const [previousColCount, setPreviousColCount] = useState(colCount)
 
-  const goToCell = useCallback((cell: Cell) => {
-    setCell(cell)
+  const scrollAndFocusCell = useCallback((cell: Cell) => {
     scrollRowIntoView?.({ rowIndex: cell.rowIndex })
     // after scrolling, focus the cell (and scroll horizontally into view if needed - see focusCurrentCell)
     setShouldFocus(true)
   }, [scrollRowIntoView])
+
+  const goToCell = useCallback((cell: Cell) => {
+    setCell(cell)
+    scrollAndFocusCell(cell)
+  }, [scrollAndFocusCell])
 
   // Reset the cell position if the number of rows has decreased and the current row index is out of bounds
   if (rowCount !== previousRowCount) {
@@ -62,9 +66,9 @@ export function CellNavigationProvider({ children, focus = true }: Props) {
     goToCell({ colIndex: 1, rowIndex: 1 })
   }, [goToCell])
 
-  const goToCurrentCell = useCallback(() => {
-    goToCell(cell)
-  }, [goToCell, cell])
+  const scrollAndFocusCurrentCell = useCallback(() => {
+    scrollAndFocusCell(cell)
+  }, [scrollAndFocusCell, cell])
 
   // Focus the first cell on mount, or on later changes, so keyboard navigation works
   if (data !== lastData) {
@@ -102,10 +106,10 @@ export function CellNavigationProvider({ children, focus = true }: Props) {
       rowCount,
       focusCurrentCell,
       goToCell,
-      goToCurrentCell,
       goToFirstCell,
+      scrollAndFocusCurrentCell,
     }
-  }, [cell, colCount, rowCount, focusCurrentCell, goToCell, goToCurrentCell, goToFirstCell])
+  }, [cell, colCount, rowCount, focusCurrentCell, goToCell, goToFirstCell, scrollAndFocusCurrentCell])
 
   return (
     <CellNavigationContext.Provider value={value}>


### PR DESCRIPTION
We don't need to set the current cell again, when we only need to scroll to it. That's why we change `goToCurrentCell` to `scrollAndFocusCurrentCell`.