### PR TITLE
[refactor] change the logic to follow React rules

### DIFF
--- a/src/providers/CellNavigationProvider.tsx
+++ b/src/providers/CellNavigationProvider.tsx
@@ -19,6 +19,8 @@ type CellNavigationProviderProps = Pick<HighTableProps, 'focus'> & {
  */
 export function CellNavigationProvider({ children, focus = true }: CellNavigationProviderProps) {
   const [cell, setCell] = useState<Cell>(defaultCellNavigationContext.cell)
+  // TODO(SL): this state should be removed, and a state should be added in useCellFocus,
+  // since the logic in React is to describe UI state through props and not through imperative code.
   const [shouldFocus, setShouldFocus] = useState(false)
   const [lastData, setLastData] = useState<Omit<DataFrame, 'numRows'> | undefined>(undefined)
   const { data } = useContext(DataContext)


### PR DESCRIPTION
- props: if validated, used them, if not, report an error and show the most adequate content
- don't use useEffect
- in a component, adapt local state if needed, run effects if needed (scroll, focus), and pass computed values down
- the only way to send data up is on mount (ref callbacks) and on events (user interactions, mainly)
- the props are for describing the UI, not for actions
- memoize when possible

Slightly changing the logic to follow the React rules will make it easier (and more reliable) to add two props to HighTable: `cell` and `setCell`, to control the navigation from the parent (i.e. an alternative to https://github.com/hyparam/hightable/pull/396). We did it the same way for `orderBy` and `selection`.