### PR TITLE
Collect keys from first 100 rows for arrayDataFrame

### DIFF
--- a/src/helpers/dataframe/array.ts
+++ b/src/helpers/dataframe/array.ts
@@ -20,7 +20,7 @@ export function arrayDataFrame<M extends Obj, C extends Obj>(
 ): ArrayData & DataFrame<M, C> {
   // Use the keys of the first row as column names if no column descriptors are provided.
   const columnDescriptors = options.columnDescriptors
-    ?? Object.keys(array[0] ?? {}).map(name => ({ name }))
+    ?? getKeysFromArray(array).map(name => ({ name }))
 
   const eventTarget = createEventTarget<DataFrameEvents>()
 
@@ -81,4 +81,17 @@ export function arrayDataFrame<M extends Obj, C extends Obj>(
   }
 
   return data
+}
+
+/**
+ * Get all unique keys from the first 100 objects in the array.
+ */
+function getKeysFromArray(array: Record<string, any>[], limit = 100): string[] {
+  const keys = new Set<string>()
+  for (const item of array.slice(0, limit)) {
+    for (const key of Object.keys(item)) {
+      keys.add(key)
+    }
+  }
+  return Array.from(keys)
 }

--- a/test/helpers/dataframe/array.test.ts
+++ b/test/helpers/dataframe/array.test.ts
@@ -17,6 +17,16 @@ describe('arrayDataFrame', () => {
     expect(df.numRows).toBe(3)
   })
 
+  it('should collect keys from multiple rows', () => {
+    const data = [
+      { id: 1, name: 'Alice' },
+      { id: 2, age: 25 },
+      { id: 3, email: 'charlie@example.com' },
+    ]
+    const df = arrayDataFrame(data)
+    expect(df.columnDescriptors).toEqual(['id', 'name', 'age', 'email'].map(name => ({ name })))
+  })
+
   it('should return the cell value without first fetching the column', () => {
     const df = arrayDataFrame(createTestData())
     const cell = df.getCell({ row: 1, column: 'name' })


### PR DESCRIPTION
Previously it would only look at the first row. This resulted in sub-optimal dataframes with missing columns for data like:

```js
[
  { id: 1, name: 'Alice' },
  { id: 2, age: 25 },
  { id: 3, email: 'charlie@example.com' },
]
```

This PR changes it to aggregate the keys of up to the first 100 rows of json objects. This should help with jsonl files especially.
