### PR TITLE
Pass onWarn, similarly to onError, to avoid hardcoded console.warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ interface TableProps {
   onColumnsVisibilityChange?: (columnVisibilityStates: Record<string, MaybeHiddenColumn>) => void // columns visibility change handler
   onDoubleClickCell?: (event: MouseEvent, col: number, row: number) => void // double-click handler
   onError?: (error: Error) => void // error handler
+  onWarn?: (message: string) => void // warning handler
   onKeyDownCell?: (event: KeyboardEvent, col: number, row: number) => void // key down handler. For accessibility, it should be passed if onDoubleClickCell is passed.
   onMouseDownCell?: (event: MouseEvent, col: number, row: number) => void // mouse down handler
   onOrderByChange?: (orderBy: OrderBy) => void // orderBy change handler

--- a/src/components/HighTable/HighTable.controlled.test.tsx
+++ b/src/components/HighTable/HighTable.controlled.test.tsx
@@ -107,25 +107,25 @@ describe('in controlled selection state (selection and onSelection props), ', ()
     expect(onSelectionChange).not.toHaveBeenCalled()
   })
 
-  it('removing selection prop is ignored and a warning is printed in the console', async () => {
+  it('removing selection prop is ignored and a warning is emitted', async () => {
     const start = 2
     const selection = { ranges: [{ start, end: start + 1 }], anchor: start }
     const onSelectionChange = vi.fn()
-    console.warn = vi.fn()
+    const onWarn = vi.fn()
 
-    const { getByRole, queryByRole, findByRole, rerender } = render(<HighTable data={data} selection={selection} onSelectionChange={onSelectionChange} />)
+    const { getByRole, queryByRole, findByRole, rerender } = render(<HighTable data={data} selection={selection} onSelectionChange={onSelectionChange} onWarn={onWarn} />)
     await waitFor(() => {
       expect(getByRole('grid').getAttribute('aria-busy')).toBe('false')
     })
     // await because we have to wait for the data to be fetched first
     await findByRole('row', { selected: true })
-    expect(console.warn).not.toHaveBeenCalled()
+    expect(onWarn).not.toHaveBeenCalled()
 
     const newSelection = undefined
-    rerender(<HighTable data={data} selection={newSelection} onSelectionChange={onSelectionChange} />)
+    rerender(<HighTable data={data} selection={newSelection} onSelectionChange={onSelectionChange} onWarn={onWarn} />)
     // no need to await because the data is already fetched
     expect(queryByRole('row', { selected: true })).not.toBeNull()
-    expect(console.warn).toHaveBeenNthCalledWith(1, expect.stringMatching(/cannot be set to undefined/))
+    expect(onWarn).toHaveBeenNthCalledWith(1, expect.stringMatching(/cannot be set to undefined/))
   })
 
   it('on data change, onSelection is not called and the selection stays the same', async () => {

--- a/src/components/HighTable/HighTable.selection.test.tsx
+++ b/src/components/HighTable/HighTable.selection.test.tsx
@@ -138,28 +138,26 @@ describe('in uncontrolled selection state (onSelection prop), ', () => {
     expect(onSelectionChange).not.toHaveBeenCalled()
   })
 
-  it('passing the selection prop is ignored and a warning is printed in the console', async () => {
+  it('passing the selection prop is ignored and a warning is emitted', async () => {
     const start = 2
-    const selection = undefined
     const onSelectionChange = vi.fn()
-    console.warn = vi.fn()
+    const onWarn = vi.fn()
 
-    const { queryByRole, findByRole, rerender } = render(<HighTable data={data} selection={selection} onSelectionChange={onSelectionChange} />)
+    const { queryByRole, findByRole, rerender } = render(<HighTable data={data} selection={undefined} onSelectionChange={onSelectionChange} onWarn={onWarn} />)
     // await because we have to wait for the data to be fetched first
     await findByRole('cell', { name: 'row 2' })
     expect(queryByRole('row', { selected: true })).toBeNull()
-    expect(console.warn).not.toHaveBeenCalled()
+    expect(onWarn).not.toHaveBeenCalled()
 
     const newSelection = { ranges: [{ start, end: start + 1 }], anchor: start }
-    rerender(<HighTable data={data} selection={newSelection} onSelectionChange={onSelectionChange} />)
+    rerender(<HighTable data={data} selection={newSelection} onSelectionChange={onSelectionChange} onWarn={onWarn} />)
     // no need to await because the data is already fetched
     expect(queryByRole('row', { selected: true })).toBeNull()
-    expect(console.warn).toHaveBeenNthCalledWith(1, expect.stringMatching(/cannot be set to a value/))
+    expect(onWarn).toHaveBeenNthCalledWith(1, expect.stringMatching(/cannot be set to a value/))
   })
 
   it.for(['Control', 'Meta'])('%s+A selects all the rows', async (ctrlKey) => {
     const onSelectionChange = vi.fn()
-    console.warn = vi.fn()
 
     const { user, queryAllByRole, findByRole } = render(<HighTable data={data} onSelectionChange={onSelectionChange} />)
     // await because we have to wait for the data to be fetched first

--- a/src/components/HighTable/HighTable.tsx
+++ b/src/components/HighTable/HighTable.tsx
@@ -3,9 +3,9 @@ import { ErrorProvider } from '../../providers/ErrorProvider.js'
 import type { HighTableProps } from '../../types.js'
 import Wrapper from './Wrapper.js'
 
-export default function HighTable({ data, maxRowNumber, onError, ...rest }: HighTableProps) {
+export default function HighTable({ data, maxRowNumber, onError, onWarn, ...rest }: HighTableProps) {
   return (
-    <ErrorProvider onError={onError}>
+    <ErrorProvider onError={onError} onWarn={onWarn}>
       <DataProvider data={data} maxRowNumber={maxRowNumber}>
         <Wrapper {...rest} />
       </DataProvider>

--- a/src/components/HighTable/Scroller.tsx
+++ b/src/components/HighTable/Scroller.tsx
@@ -2,6 +2,7 @@ import type { KeyboardEvent } from 'react'
 import { useCallback, useContext, useMemo } from 'react'
 
 import { CellNavigationContext } from '../../contexts/CellNavigationContext.js'
+import { ErrorContext } from '../../contexts/ErrorContext.js'
 import { ScrollContext } from '../../contexts/ScrollContext.js'
 import styles from '../../HighTable.module.css'
 
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export default function Scroller({ children, setViewportWidth }: Props) {
+  const { onWarn } = useContext(ErrorContext)
   const { scrollAndFocusCurrentCell } = useContext(CellNavigationContext)
   const { canvasHeight, sliceTop, setClientHeight, setScrollTop, setScrollTo } = useContext(ScrollContext)
 
@@ -75,7 +77,7 @@ export default function Scroller({ children, setViewportWidth }: Props) {
     const resizeObserver = 'ResizeObserver' in window
       ? new window.ResizeObserver(([entry]) => {
           if (!entry) {
-            console.warn('ResizeObserver entry is not available.')
+            onWarn('ResizeObserver entry is not available.')
             return
           }
           updateViewportSize()
@@ -90,7 +92,7 @@ export default function Scroller({ children, setViewportWidth }: Props) {
       resizeObserver?.disconnect()
       viewport.removeEventListener('scroll', handleScroll)
     }
-  }, [setScrollTo, setViewportWidth, setClientHeight, setScrollTop])
+  }, [onWarn, setScrollTo, setViewportWidth, setClientHeight, setScrollTop])
 
   // TODO(SL): maybe pass CSS variables instead of inline styles?
   // the viewport div scrollHeight will be equal to canvasHeight (unless custom CSS is messing with it)

--- a/src/components/HighTable/Wrapper.tsx
+++ b/src/components/HighTable/Wrapper.tsx
@@ -17,7 +17,7 @@ import type { HighTableProps } from '../../types.js'
 import Scroller from './Scroller.js'
 import Slice from './Slice.js'
 
-type Props = Omit<HighTableProps, 'data' | 'maxRowNumber' | 'onError'>
+type Props = Omit<HighTableProps, 'data' | 'maxRowNumber' | 'onError' | 'onWarn'>
 
 export default function Wrapper({
   columnConfiguration,

--- a/src/components/TableCorner/TableCorner.tsx
+++ b/src/components/TableCorner/TableCorner.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent, CSSProperties, KeyboardEvent, ReactNode } from 'react'
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 
+import { ErrorContext } from '../../contexts/ErrorContext.js'
 import { useCellFocus } from '../../hooks/useCellFocus.js'
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
 }
 
 export default function TableCorner({ children, checked, onCheckboxPress, pendingSelectionGesture, style, ariaColIndex, ariaRowIndex, setTableCornerSize }: Props) {
+  const { onWarn } = useContext(ErrorContext)
   const { tabIndex, navigateToCell, focusCellIfNeeded } = useCellFocus({ ariaColIndex, ariaRowIndex })
 
   const handleClick = useCallback(() => {
@@ -61,7 +63,7 @@ export default function TableCorner({ children, checked, onCheckboxPress, pendin
     // listener
     const resizeObserver = new window.ResizeObserver(([entry]) => {
       if (!entry) {
-        console.warn('ResizeObserver entry is not available.')
+        onWarn('ResizeObserver entry is not available.')
         return
       }
       updateTableCornerSize()
@@ -72,7 +74,7 @@ export default function TableCorner({ children, checked, onCheckboxPress, pendin
       resizeObserver.disconnect()
     }
     /* Track the size of the table corner */
-  }, [setTableCornerSize])
+  }, [onWarn, setTableCornerSize])
 
   const ref = useCallback((tableCorner: HTMLTableCellElement | null) => {
     focusCellIfNeeded(tableCorner)

--- a/src/contexts/ErrorContext.ts
+++ b/src/contexts/ErrorContext.ts
@@ -1,10 +1,14 @@
 import { createContext } from 'react'
 
 interface ErrorContextType {
-  /** Optional callback to call when an error occurs. */
+  /** Optional callback to call when an error occurs (generally from a catch block). */
   onError?: (error: unknown) => void
+  /** Function called to issue a warning message. */
+  onWarn: (message: string) => void
 }
 
-export const defaultErrorContext: ErrorContextType = {}
+export const defaultErrorContext: ErrorContextType = {
+  onWarn: console.warn,
+}
 
 export const ErrorContext = createContext<ErrorContextType>(defaultErrorContext)

--- a/src/hooks/useInputState.ts
+++ b/src/hooks/useInputState.ts
@@ -1,4 +1,6 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
+
+import { ErrorContext } from '../contexts/ErrorContext.js'
 
 /**
  * Props for the useInputState hook.
@@ -33,6 +35,7 @@ interface UseInputStateResult<T> {
  * If the initial value is defined, but not the onChange prop, the input is read-only (no interactions).
  */
 export function useInputState<T>({ value, onChange, defaultValue }: UseInputStateProps<T>): UseInputStateResult<T> {
+  const { onWarn } = useContext(ErrorContext)
   const [initialValue] = useState<T | undefined>(value)
 
   // for uncontrolled inputs
@@ -49,7 +52,7 @@ export function useInputState<T>({ value, onChange, defaultValue }: UseInputStat
   // - controlled (no local state)
   if (initialValue !== undefined) {
     if (value === undefined) {
-      console.warn('The value is controlled (it has no local state) because the property was initially defined. It cannot be set to undefined now (it is set back to the initial value).')
+      onWarn('The value is controlled (it has no local state) because the property was initially defined. It cannot be set to undefined now (it is set back to the initial value).')
     }
     return {
       value: value ?? initialValue,
@@ -60,7 +63,7 @@ export function useInputState<T>({ value, onChange, defaultValue }: UseInputStat
 
   // - uncontrolled (local state)
   if (value !== undefined) {
-    console.warn('The value is uncontrolled (it only has a local state) because the property was initially undefined. It cannot be set to a value now and is ignored.')
+    onWarn('The value is uncontrolled (it only has a local state) because the property was initially undefined. It cannot be set to a value now and is ignored.')
   }
   return { value: localValue, onChange: uncontrolledOnChange }
 }

--- a/src/providers/ColumnParametersProvider.tsx
+++ b/src/providers/ColumnParametersProvider.tsx
@@ -1,6 +1,7 @@
-import { type ReactNode, useMemo } from 'react'
+import { type ReactNode, useContext, useMemo } from 'react'
 
 import { type ColumnParameters, ColumnParametersContext } from '../contexts/ColumnParametersContext.js'
+import { ErrorContext } from '../contexts/ErrorContext.js'
 import type { ColumnDescriptor } from '../helpers/dataframe/index.js'
 import type { HighTableProps } from '../types.js'
 
@@ -15,6 +16,7 @@ type Props = Pick<HighTableProps, 'columnConfiguration'> & {
  * Provide the columns configuration to the table, through the ColumnParametersContext.
  */
 export function ColumnParametersProvider({ columnConfiguration, columnDescriptors, children }: Props) {
+  const { onWarn } = useContext(ErrorContext)
   const value = useMemo(() => {
     const inHeader = new Set(columnDescriptors.map(c => c.name))
 
@@ -29,7 +31,7 @@ export function ColumnParametersProvider({ columnConfiguration, columnDescriptor
     if (columnConfiguration) {
       for (const k of Object.keys(columnConfiguration)) {
         if (!inHeader.has(k)) {
-          console.warn(
+          onWarn(
             `[HighTable] columnConfiguration has unknown key “${k}”. It will be ignored.`
           )
         }
@@ -37,7 +39,7 @@ export function ColumnParametersProvider({ columnConfiguration, columnDescriptor
     }
 
     return cols
-  }, [columnDescriptors, columnConfiguration])
+  }, [columnDescriptors, columnConfiguration, onWarn])
 
   return (
     <ColumnParametersContext.Provider value={value}>

--- a/src/providers/ErrorProvider.tsx
+++ b/src/providers/ErrorProvider.tsx
@@ -1,20 +1,21 @@
 import type { ReactNode } from 'react'
 import { useMemo } from 'react'
 
-import { ErrorContext } from '../contexts/ErrorContext.js'
+import { defaultErrorContext, ErrorContext } from '../contexts/ErrorContext.js'
 import type { HighTableProps } from '../types.js'
 
-type Props = Pick<HighTableProps, 'onError'> & {
+type Props = Pick<HighTableProps, 'onError' | 'onWarn'> & {
   children: ReactNode
 }
 
 /**
  * Provides error handling functionality to the table, through the ErrorContext.
  */
-export function ErrorProvider({ children, onError }: Props) {
+export function ErrorProvider({ children, onError, onWarn = defaultErrorContext.onWarn }: Props) {
   const value = useMemo(() => ({
     onError,
-  }), [onError])
+    onWarn,
+  }), [onError, onWarn])
 
   return (
     <ErrorContext.Provider value={value}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,13 +56,23 @@ export interface HighTableProps {
   // TODO(SL): replace col: number with col: string?
   onDoubleClickCell?: (event: MouseEvent, col: number, row: number) => void
   /**
-   * Optional function called when an error occurs.
+   * Optional function called when an error occurs, generally from a catch block.
+   *
+   * It is generally an Error object, but for type safety, it is typed as unknown.
    *
    * Ignored if not set.
    *
    * @param error The error that occurred
    */
   onError?: (error: unknown) => void
+  /**
+   * Optional function called when a warning message is issued.
+   *
+   * console.warn is used by default if not provided.
+   *
+   * @param message The warning message
+   */
+  onWarn?: (message: string) => void
   /**
    * Optional function called on key down of a cell.
    *


### PR DESCRIPTION
Note that it still defaults to console.warn if not set, to avoid breaking change.

Basically, it gives a way to get the warnings from the parent, while still outputting to the console by default.