### PR TITLE
Increase stringify float precision

### DIFF
--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -3,7 +3,9 @@
  */
 export function stringify(value: unknown): string | undefined {
   if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'bigint') return value.toLocaleString('en-US')
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return value.toLocaleString('en-US', { maximumFractionDigits: 7 })
+  }
   if (typeof value === 'boolean') return value.toString()
   if (Array.isArray(value)) {
     return `[\n${value.map(v => indent(stringify(v), 2)).join(',\n')}\n]`

--- a/test/utils/stringify.test.ts
+++ b/test/utils/stringify.test.ts
@@ -9,6 +9,22 @@ describe('stringify', () => {
 
   test('returns the localized string if input is a number', () => {
     expect(stringify(4200)).toBe('4,200')
+    expect(stringify(3.14159265359)).toBe('3.1415927')
+    expect(stringify(1.23456789)).toBe('1.2345679')
+    expect(stringify(0.0000001)).toBe('0.0000001')
+    expect(stringify(0.00000001)).toBe('0')
+    expect(stringify(-0.00000001)).toBe('-0')
+    expect(stringify(0)).toBe('0')
+    expect(stringify(-0)).toBe('-0')
+    expect(stringify(123.456)).toBe('123.456')
+    expect(stringify(1000.123456789)).toBe('1,000.1234568')
+    expect(stringify(1234567890)).toBe('1,234,567,890')
+    expect(stringify(9876543210.125)).toBe('9,876,543,210.125')
+    expect(stringify(1e15)).toBe('1,000,000,000,000,000')
+    expect(stringify(1.23e20)).toBe('123,000,000,000,000,000,000')
+    expect(stringify(Infinity)).toBe('∞')
+    expect(stringify(-Infinity)).toBe('-∞')
+    expect(stringify(NaN)).toBe('NaN')
   })
 
   test('stringifies null and undefined as JSON', () => {
@@ -65,6 +81,8 @@ describe('stringify', () => {
   test('handles bigints', () => {
     expect(stringify(BigInt(123))).toBe('123')
     expect(stringify(BigInt(4200))).toBe('4,200')
+    expect(stringify(BigInt(1234567890))).toBe('1,234,567,890')
+    expect(stringify(BigInt(-1234567890))).toBe('-1,234,567,890')
   })
 
   test('handles errors', () => {


### PR DESCRIPTION
Increase `stringify` float precision from 3 to 7. HighTable is made to display long text.

Fix for #414
