### PR TITLE
Fix sorting of falsey values

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default defineConfig([
       js.configs.recommended,
     ],
     rules: {
-      eqeqeq: 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
       'func-style': ['error', 'declaration', { allowTypeAnnotation: true }],
       'prefer-destructuring': ['error', { object: true, array: false }],
     },

--- a/src/helpers/sort.ts
+++ b/src/helpers/sort.ts
@@ -94,10 +94,12 @@ export function toggleColumnExclusive(column: string, orderBy: OrderBy): OrderBy
   return [{ column, direction: 'ascending' }]
 }
 
-// TODO(SL): test
 export function computeRanks(values: any[]): number[] {
   const valuesWithIndex = values.map((value, index) => ({ value, index }))
   const sortedValuesWithIndex = Array.from(valuesWithIndex).sort(({ value: a }, { value: b }) => {
+    if (a == null && b == null) return 0
+    if (a == null) return 1
+    if (b == null) return -1
     if (a < b) return -1
     if (a > b) return 1
     return 0

--- a/test/helpers/sort.test.ts
+++ b/test/helpers/sort.test.ts
@@ -94,4 +94,30 @@ describe('computeRanks', () => {
     const ranks = computeRanks(values)
     expect(ranks).toEqual([2, 3, 0, 0])
   })
+
+  it('should sort null after other values', () => {
+    expect(computeRanks([null, 1, 2])).toEqual([2, 0, 1])
+    expect(computeRanks([1, null, 2])).toEqual([0, 2, 1])
+    expect(computeRanks([1, 2, null])).toEqual([0, 1, 2])
+  })
+
+  it('should sort undefined after other values', () => {
+    expect(computeRanks([undefined, 1, 2])).toEqual([2, 0, 1])
+    expect(computeRanks([1, undefined, 2])).toEqual([0, 2, 1])
+  })
+
+  it('should sort null and undefined after other values', () => {
+    expect(computeRanks([null, undefined, 1])).toEqual([1, 2, 0])
+    expect(computeRanks([1, null, undefined])).toEqual([0, 1, 2])
+  })
+
+  it('should sort null and false as different values', () => {
+    expect(computeRanks([null, false, true])).toEqual([2, 0, 1])
+    expect(computeRanks([false, null, true])).toEqual([0, 2, 1])
+  })
+
+  it('should sort null after zero', () => {
+    expect(computeRanks([null, 0, 1])).toEqual([2, 0, 1])
+    expect(computeRanks([0, null, 1])).toEqual([0, 2, 1])
+  })
 })


### PR DESCRIPTION
Fix for #428

False and null values were being treated as falsey values and sorting together as ties. This PR sorts nulls at the end.
