### PR TITLE
[refactor] create CellConfigurationProvider

### DIFF
--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,17 +1,10 @@
-import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
+import type { KeyboardEvent, MouseEvent } from 'react'
 import { useCallback, useContext, useEffect, useMemo, useRef } from 'react'
 
+import { CellCallbacksContext, RenderCellContentContext, StringifyContext } from '../contexts/CellConfigurationContext.js'
 import { ColumnWidthsContext } from '../contexts/ColumnWidthsContext.js'
-import type { ResolvedValue } from '../helpers/dataframe/index.js'
 import { useCellFocus } from '../hooks/useCellFocus.js'
 import { useOnCopy } from '../hooks/useOnCopyToClipboard.js'
-
-export interface CellContentProps {
-  stringify: (value: unknown) => string | undefined
-  cell?: ResolvedValue
-  col: number
-  row?: number // the row index in the original data, undefined if the value has not been fetched yet
-}
 
 interface Props {
   /** aria column index */
@@ -22,30 +15,23 @@ interface Props {
   columnIndex: number
   /** index in the visible columns array (used for styling/widths) */
   visibleColumnIndex: number
-  /** function to stringify the cell value, used for default rendering and for copy to clipboard */
-  stringify: (value: unknown) => string | undefined
   /** cell value, undefined if the value has not been fetched yet, or if the value is actually undefined. Use hasResolved to distinguish these cases. */
   cellValue?: unknown
   /** whether the cell value has been resolved */
   hasResolved?: boolean
   /** class name */
   className?: string
-  /** double click callback */
-  onDoubleClickCell?: (event: MouseEvent, col: number, row: number) => void
-  /** mouse down callback */
-  onMouseDownCell?: (event: MouseEvent, col: number, row: number) => void
-  /** key down callback, for accessibility, it should be passed if onDoubleClickCell is passed. It can handle more than that action though. */
-  onKeyDownCell?: (event: KeyboardEvent, col: number, row: number) => void
   /** the row index in the original data, undefined if the value has not been fetched yet */
   rowNumber?: number
-  /** custom cell content component, if not provided, the default stringified value will be used */
-  renderCellContent?: (props: CellContentProps) => ReactNode
 }
 
 /**
  * Render a table cell <td> with title and optional custom rendering
  */
-export default function Cell({ cellValue, hasResolved, onDoubleClickCell, onMouseDownCell, onKeyDownCell, stringify, columnIndex, visibleColumnIndex, className, ariaColIndex, ariaRowIndex, rowNumber, renderCellContent }: Props) {
+export default function Cell({ cellValue, hasResolved, columnIndex, visibleColumnIndex, className, ariaColIndex, ariaRowIndex, rowNumber }: Props) {
+  const { onDoubleClickCell, onMouseDownCell, onKeyDownCell } = useContext(CellCallbacksContext)
+  const stringify = useContext(StringifyContext)
+  const renderCellContent = useContext(RenderCellContentContext)
   const { tabIndex, navigateToCell, focusIfNeeded } = useCellFocus({ ariaColIndex, ariaRowIndex })
 
   const cell = useMemo(() => {

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -65,7 +65,9 @@ export default function Cell({ cellValue, hasResolved, columnIndex, visibleColum
     }
   }, [str])
   const content = useMemo(() => {
-    return renderCellContent?.({ cell, stringify, col: columnIndex, row: rowNumber }) ?? str
+    return renderCellContent === undefined
+      ? str
+      : renderCellContent({ cell, stringify, col: columnIndex, row: rowNumber })
   }, [cell, stringify, columnIndex, rowNumber, renderCellContent, str])
 
   const handleMouseDown = useCallback((event: MouseEvent) => {

--- a/src/components/HighTable.tsx
+++ b/src/components/HighTable.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react'
 
 import { columnWidthsSuffix } from '../helpers/constants.js'
 import styles from '../HighTable.module.css'
+import { CellConfigurationProvider } from '../providers/CellConfigurationProvider.js'
 import { CellNavigationProvider } from '../providers/CellNavigationProvider.js'
 import { ColumnParametersProvider } from '../providers/ColumnParametersProvider.js'
 import { ColumnsVisibilityProvider } from '../providers/ColumnsVisibilityProvider.js'
@@ -31,7 +32,7 @@ export default function HighTable({ data, ...props }: HighTableProps) {
   )
 }
 
-type StateProps = Pick<HighTableProps, 'columnConfiguration' | 'cacheKey' | 'cellPosition' | 'columnsVisibility' | 'focus' | 'numRowsPerPage' | 'orderBy' | 'overscan' | 'padding' | 'selection' | 'onCellPositionChange' | 'onColumnsVisibilityChange' | 'onError' | 'onOrderByChange' | 'onSelectionChange'>
+type StateProps = Pick<HighTableProps, 'columnConfiguration' | 'cacheKey' | 'cellPosition' | 'columnsVisibility' | 'focus' | 'numRowsPerPage' | 'orderBy' | 'overscan' | 'padding' | 'selection' | 'onCellPositionChange' | 'onColumnsVisibilityChange' | 'onDoubleClickCell' | 'onError' | 'onKeyDownCell' | 'onMouseDownCell' | 'onOrderByChange' | 'onSelectionChange' | 'renderCellContent' | 'stringify'>
   & { children: ReactNode }
 
 function State({
@@ -48,65 +49,73 @@ function State({
   selection,
   onCellPositionChange,
   onColumnsVisibilityChange,
+  onDoubleClickCell,
   onError,
+  onKeyDownCell,
+  onMouseDownCell,
   onOrderByChange,
   onSelectionChange,
+  renderCellContent,
+  stringify,
 }: StateProps) {
   return (
     /* The state is handled with contexts, even if it creates a "Providers hell". No need for state library for now. */
     <ViewportSizeProvider>
       <TableCornerSizeProvider>
-        <ColumnParametersProvider columnConfiguration={columnConfiguration}>
-          <ColumnWidthsProvider
+        <CellConfigurationProvider
+          onDoubleClickCell={onDoubleClickCell}
+          onKeyDownCell={onKeyDownCell}
+          onMouseDownCell={onMouseDownCell}
+          renderCellContent={renderCellContent}
+          stringify={stringify}
+        >
+          <ColumnParametersProvider columnConfiguration={columnConfiguration}>
+            <ColumnWidthsProvider
             // Recreate a context if a new cacheKey is provided.
-            key={cacheKey}
-            // TODO(SL): pass cacheKey, memoize
-            localStorageKey={cacheKey ? `${cacheKey}${columnWidthsSuffix}` : undefined}
-          >
-            <ColumnsVisibilityProvider
-              columnsVisibility={columnsVisibility}
-              onColumnsVisibilityChange={onColumnsVisibilityChange}
+              key={cacheKey}
+              // TODO(SL): pass cacheKey, memoize
+              localStorageKey={cacheKey ? `${cacheKey}${columnWidthsSuffix}` : undefined}
             >
-              <OrderByProvider
-                orderBy={orderBy}
-                onOrderByChange={onOrderByChange}
+              <ColumnsVisibilityProvider
+                columnsVisibility={columnsVisibility}
+                onColumnsVisibilityChange={onColumnsVisibilityChange}
               >
-                <SelectionProvider
-                  selection={selection}
-                  onError={onError}
-                  onSelectionChange={onSelectionChange}
+                <OrderByProvider
+                  orderBy={orderBy}
+                  onOrderByChange={onOrderByChange}
                 >
-                  <CellNavigationProvider
-                    cellPosition={cellPosition}
-                    focus={focus}
-                    numRowsPerPage={numRowsPerPage}
-                    onCellPositionChange={onCellPositionChange}
+                  <SelectionProvider
+                    selection={selection}
+                    onError={onError}
+                    onSelectionChange={onSelectionChange}
                   >
-                    <ScrollProvider padding={padding} onError={onError} overscan={overscan}>
-                      {children}
-                    </ScrollProvider>
-                  </CellNavigationProvider>
-                </SelectionProvider>
-              </OrderByProvider>
-            </ColumnsVisibilityProvider>
-          </ColumnWidthsProvider>
-        </ColumnParametersProvider>
+                    <CellNavigationProvider
+                      cellPosition={cellPosition}
+                      focus={focus}
+                      numRowsPerPage={numRowsPerPage}
+                      onCellPositionChange={onCellPositionChange}
+                    >
+                      <ScrollProvider padding={padding} onError={onError} overscan={overscan}>
+                        {children}
+                      </ScrollProvider>
+                    </CellNavigationProvider>
+                  </SelectionProvider>
+                </OrderByProvider>
+              </ColumnsVisibilityProvider>
+            </ColumnWidthsProvider>
+          </ColumnParametersProvider>
+        </CellConfigurationProvider>
       </TableCornerSizeProvider>
     </ViewportSizeProvider>
   )
 }
 
-type DOMProps = Pick<HighTableProps, 'className' | 'maxRowNumber' | 'styled' | 'onDoubleClickCell' | 'onKeyDownCell' | 'onMouseDownCell' | 'renderCellContent' | 'stringify'>
+type DOMProps = Pick<HighTableProps, 'className' | 'maxRowNumber' | 'styled'>
 
 function DOM({
   className = '',
   maxRowNumber,
   styled = true,
-  onDoubleClickCell,
-  onKeyDownCell,
-  onMouseDownCell,
-  renderCellContent,
-  stringify,
 }: DOMProps) {
   return (
     <Wrapper styled={styled} maxRowNumber={maxRowNumber} className={className}>
@@ -114,13 +123,7 @@ function DOM({
 
       <Scroller>
         <Slice>
-          <Table
-            onDoubleClickCell={onDoubleClickCell}
-            onKeyDownCell={onKeyDownCell}
-            onMouseDownCell={onMouseDownCell}
-            renderCellContent={renderCellContent}
-            stringify={stringify}
-          />
+          <Table />
         </Slice>
       </Scroller>
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -8,23 +8,13 @@ import { OrderByContext } from '../contexts/OrderByContext.js'
 import { RenderedRowsContext } from '../contexts/ScrollContext.js'
 import { SelectionContext } from '../contexts/SelectionContext.js'
 import { ariaOffset } from '../helpers/constants.js'
-import type { HighTableProps } from '../types.js'
-import { stringify as stringifyDefault } from '../utils/stringify.js'
 import Cell from './Cell.js'
 import Row from './Row.js'
 import RowHeader from './RowHeader.js'
 import TableCorner from './TableCorner.js'
 import TableHeader from './TableHeader.js'
 
-type TableProps = Pick<HighTableProps, 'onDoubleClickCell' | 'onKeyDownCell' | 'onMouseDownCell' | 'renderCellContent' | 'stringify'>
-
-export default function Table({
-  onDoubleClickCell,
-  onKeyDownCell,
-  onMouseDownCell,
-  renderCellContent,
-  stringify = stringifyDefault,
-}: TableProps) {
+export default function Table() {
   const { moveCell } = useContext(CellNavigationContext)
   const orderBy = useContext(OrderByContext)
   const { selectable, toggleAllRows, pendingSelectionGesture, onTableKeyDown: onSelectionTableKeyDown, allRowsSelected, isRowSelected, toggleRowNumber, toggleRangeToRowNumber } = useContext(SelectionContext)
@@ -214,10 +204,6 @@ export default function Table({
                 return (
                   <Cell
                     key={columnIndex}
-                    onDoubleClickCell={onDoubleClickCell}
-                    onMouseDownCell={onMouseDownCell}
-                    onKeyDownCell={onKeyDownCell}
-                    stringify={stringify}
                     columnIndex={columnIndex}
                     visibleColumnIndex={visibleColumnIndex}
                     className={className}
@@ -226,7 +212,6 @@ export default function Table({
                     cellValue={cell?.value}
                     hasResolved={cell !== undefined}
                     rowNumber={rowNumber}
-                    renderCellContent={renderCellContent}
                   />
                 )
               })}

--- a/src/contexts/CellConfigurationContext.ts
+++ b/src/contexts/CellConfigurationContext.ts
@@ -10,7 +10,8 @@ export const StringifyContext = createContext<(value: unknown) => string | undef
 /** custom cell content component, if not provided, the default stringified value will be used */
 export const RenderCellContentContext = createContext<((props: CellContentProps) => ReactNode) | undefined>(undefined)
 
-export const CellCallbacksContext = createContext <{
+/** callbacks for cell interactions (click, double click and key down), used for accessibility and custom interactions */
+export const CellCallbacksContext = createContext<{
   /** double click callback */
   onDoubleClickCell?: (event: MouseEvent, col: number, row: number) => void
   /** mouse down callback */

--- a/src/contexts/CellConfigurationContext.ts
+++ b/src/contexts/CellConfigurationContext.ts
@@ -1,11 +1,11 @@
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
 import { createContext } from 'react'
 
-import type { CellContentProps } from '../types.js'
+import type { CellContentProps, StringifyFunction } from '../types.js'
 import { stringify } from '../utils/stringify.js'
 
 /** function to stringify the cell value, used for default rendering and for copy to clipboard */
-export const StringifyContext = createContext<(value: unknown) => string | undefined>(stringify)
+export const StringifyContext = createContext<StringifyFunction>(stringify)
 
 /** custom cell content component, if not provided, the default stringified value will be used */
 export const RenderCellContentContext = createContext<((props: CellContentProps) => ReactNode) | undefined>(undefined)

--- a/src/contexts/CellConfigurationContext.ts
+++ b/src/contexts/CellConfigurationContext.ts
@@ -1,0 +1,20 @@
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
+import { createContext } from 'react'
+
+import type { CellContentProps } from '../types.js'
+import { stringify } from '../utils/stringify.js'
+
+/** function to stringify the cell value, used for default rendering and for copy to clipboard */
+export const StringifyContext = createContext<(value: unknown) => string | undefined>(stringify)
+
+/** custom cell content component, if not provided, the default stringified value will be used */
+export const RenderCellContentContext = createContext<((props: CellContentProps) => ReactNode) | undefined>(undefined)
+
+export const CellCallbacksContext = createContext <{
+  /** double click callback */
+  onDoubleClickCell?: (event: MouseEvent, col: number, row: number) => void
+  /** mouse down callback */
+  onMouseDownCell?: (event: MouseEvent, col: number, row: number) => void
+  /** key down callback, for accessibility, it should be passed if onDoubleClickCell is passed. It can handle more than that action though. */
+  onKeyDownCell?: (event: KeyboardEvent, col: number, row: number) => void
+}>({})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import HighTable from './components/HighTable.js'
-export { type CellContentProps } from './components/Cell.js'
 export type { ColumnConfig, ColumnConfiguration, CustomMenuGroup, CustomMenuItem } from './helpers/columnConfiguration.js'
 export type { Cells, DataFrame, DataFrameEvents, ResolvedValue } from './helpers/dataframe/index.js'
 export { arrayDataFrame, checkSignal, createGetRowNumber, sortableDataFrame, validateColumn, validateFetchParams, validateGetCellParams, validateGetRowNumberParams, validateOrderBy, validateRow } from './helpers/dataframe/index.js'
@@ -7,6 +6,7 @@ export type { Selection } from './helpers/selection.js'
 export type { Direction, OrderBy } from './helpers/sort.js'
 export type { CustomEventTarget, TypedCustomEvent } from './helpers/typedEventTarget.js'
 export { createEventTarget } from './helpers/typedEventTarget.js'
+export type { CellContentProps } from './types.js'
 export { stringify } from './utils/stringify.js'
 export { HighTable }
 export default HighTable

--- a/src/providers/CellConfigurationProvider.tsx
+++ b/src/providers/CellConfigurationProvider.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode, useMemo } from 'react'
+
+import { CellCallbacksContext, RenderCellContentContext, StringifyContext } from '../contexts/CellConfigurationContext.js'
+import type { HighTableProps } from '../types.js'
+import { stringify as defaultStringify } from '../utils/stringify.js'
+
+type Props = Pick<HighTableProps, 'onDoubleClickCell' | 'onKeyDownCell' | 'onMouseDownCell' | 'renderCellContent' | 'stringify'> & {
+  /** Child components */
+  children: ReactNode
+}
+
+/**
+ * Provide cell configuration contexts.
+ */
+export function CellConfigurationProvider({ children, onDoubleClickCell, onKeyDownCell, onMouseDownCell, renderCellContent, stringify }: Props) {
+  const cellCallbacks = useMemo(() => ({
+    onDoubleClickCell,
+    onKeyDownCell,
+    onMouseDownCell,
+  }), [onDoubleClickCell, onKeyDownCell, onMouseDownCell])
+
+  // Multiple contexts, to avoid unnecessary re-renders of the components consuming the API when only the data changes, and vice-versa. See https://react.dev/reference/react/useContext#caveats for more details.
+  return (
+    <CellCallbacksContext.Provider value={cellCallbacks}>
+      <RenderCellContentContext.Provider value={renderCellContent}>
+        <StringifyContext.Provider value={stringify ?? defaultStringify}>
+          {children}
+        </StringifyContext.Provider>
+      </RenderCellContentContext.Provider>
+    </CellCallbacksContext.Provider>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,10 @@ export interface CellPosition {
   rowIndex: number
 }
 
+export type StringifyFunction = (value: unknown) => string | undefined
+
 export interface CellContentProps {
-  stringify: (value: unknown) => string | undefined
+  stringify: StringifyFunction
   cell?: ResolvedValue
   col: number
   row?: number // the row index in the original data, undefined if the value has not been fetched yet
@@ -187,8 +189,10 @@ export interface HighTableProps {
   /**
    * Optional function to stringify cell values for rendering, copy/paste and export.
    *
+   * If not provided, the default stringification will be used.
+   *
    * @param value The cell value
-   * @returns The stringified value, or undefined to use the default stringification
+   * @returns The stringified value, or undefined if the value cannot be stringified
    */
-  stringify?: (value: unknown) => string | undefined
+  stringify?: StringifyFunction
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,7 @@
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
 
-import type { CellContentProps } from './components/Cell.js'
 import type { ColumnConfiguration } from './helpers/columnConfiguration.js'
-import type { DataFrame } from './helpers/dataframe/index.js'
+import type { DataFrame, ResolvedValue } from './helpers/dataframe/index.js'
 import type { Selection } from './helpers/selection.js'
 import type { OrderBy } from './helpers/sort.js'
 import type { ColumnsVisibility } from './providers/ColumnsVisibilityProvider.js'
@@ -23,6 +22,13 @@ export interface CellPosition {
    * It's the same semantic as aria-rowindex: 1-based, includes column headers
    */
   rowIndex: number
+}
+
+export interface CellContentProps {
+  stringify: (value: unknown) => string | undefined
+  cell?: ResolvedValue
+  col: number
+  row?: number // the row index in the original data, undefined if the value has not been fetched yet
 }
 
 // TODO(SL): update selection, onSelectionChange docstrings to reflect the reality

--- a/stories/HighTable.stories.tsx
+++ b/stories/HighTable.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { MouseEvent, ReactNode } from 'react'
 import { useState } from 'react'
 
-import type { CellContentProps } from '../src/components/Cell.js'
 import HighTable from '../src/components/HighTable.js'
 import { checkSignal, createGetRowNumber, validateFetchParams, validateGetCellParams } from '../src/helpers/dataframe/helpers.js'
 import type { DataFrame, DataFrameEvents } from '../src/helpers/dataframe/index.js'
@@ -13,7 +12,7 @@ import type { Selection } from '../src/helpers/selection.js'
 import type { OrderBy } from '../src/helpers/sort.js'
 import { createEventTarget } from '../src/helpers/typedEventTarget.js'
 import type { ColumnsVisibility } from '../src/providers/ColumnsVisibilityProvider.js'
-import type { CellPosition } from '../src/types.js'
+import type { CellContentProps, CellPosition } from '../src/types.js'
 
 function random(seed: number) {
   const x = Math.sin(seed) * 10000

--- a/test/components/Cell.test.tsx
+++ b/test/components/Cell.test.tsx
@@ -2,15 +2,19 @@ import { act, fireEvent } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import Cell from '../../src/components/Cell.js'
+import { RenderCellContentContext, StringifyContext } from '../../src/contexts/CellConfigurationContext.js'
 import { render } from '../../src/utils/userEvent.js'
+
+function stringify(d: unknown) {
+  // Note that HighTable defaults to another stringifier - we don't test this here
+  return d === undefined ? 'undefined' : JSON.stringify(d)
+}
 
 const rest = {
   ariaColIndex: 1,
   ariaRowIndex: 1,
   columnIndex: 0,
   visibleColumnIndex: 0,
-  stringify: (d: unknown) => d === undefined ? 'undefined' : JSON.stringify(d),
-  // Note that HighTable defaults to another stringifier - we don't test this here
 }
 describe('Cell', () => {
   it.each([
@@ -21,56 +25,64 @@ describe('Cell', () => {
     [[1, 2, 3], '[1,2,3]'],
   ])('renders the value (%s) as string by default: %s', (value, text) => {
     const { getByText } = render(
-      <table>
-        <tbody>
-          <tr>
-            <Cell
-              cellValue={value}
-              hasResolved={true}
-              {...rest}
-            />
-          </tr>
-        </tbody>
-      </table>
+      <StringifyContext.Provider value={stringify}>
+        <table>
+          <tbody>
+            <tr>
+              <Cell
+                cellValue={value}
+                hasResolved={true}
+                {...rest}
+              />
+            </tr>
+          </tbody>
+        </table>
+      </StringifyContext.Provider>
     )
     getByText(text)
   })
 
   it('renders custom content when renderCellContent is provided', () => {
     const { getByText } = render(
-      <table>
-        <tbody>
-          <tr>
-            <Cell
-              cellValue="custom"
-              hasResolved={true}
-              renderCellContent={({ cell }) => (
-                <span>
-                  {`Value: ${cell?.value}`}
-                </span>
-              )}
-              {...rest}
-            />
-          </tr>
-        </tbody>
-      </table>
+      <StringifyContext.Provider value={stringify}>
+        <RenderCellContentContext.Provider value={({ cell }) => (
+          <span>
+            {`Value: ${cell?.value}`}
+          </span>
+        )}
+        >
+          <table>
+            <tbody>
+              <tr>
+                <Cell
+                  cellValue="custom"
+                  hasResolved={true}
+                  {...rest}
+                />
+              </tr>
+            </tbody>
+          </table>
+        </RenderCellContentContext.Provider>
+      </StringifyContext.Provider>
     )
     getByText('Value: custom')
   })
 
   it('copies the cell content to clipboard on copy event', async () => {
     const { getByText } = render(
-      <table>
-        <tbody>
-          <tr>
-            <Cell
-              cellValue={123}
-              hasResolved={true}
-              {...rest}
-            />
-          </tr>
-        </tbody>
-      </table>
+      <StringifyContext.Provider value={stringify}>
+        <table>
+          <tbody>
+            <tr>
+              <Cell
+                cellValue={123}
+                hasResolved={true}
+                {...rest}
+              />
+            </tr>
+          </tbody>
+        </table>
+      </StringifyContext.Provider>
     )
     const cell = getByText('123')
     cell.focus()


### PR DESCRIPTION
Provide five HighTable props (onDoubleClickCell, onKeyDownCell, onMouseDownCell, renderCellContent, stringify) through contexts instead of drilling to Cell